### PR TITLE
Fix debug

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ const bsb = require('binary-search-bounds')
 const debug = require('debug')("jitdb")
 
 module.exports = function (log, indexesPath) {
+  debug("indexes path", indexesPath)
+
   function saveTypedArray(name, seq, count, arr, cb) {
     const filename = path.join(indexesPath, name + ".index")
     if (!cb)

--- a/operators.js
+++ b/operators.js
@@ -174,7 +174,11 @@ function debug() {
     );
     console.log(
       'debug',
-      JSON.stringify(ops, (key, val) => (key === 'meta' ? void 0 : val), 2),
+      JSON.stringify(ops, (key, val) => {
+        if (key === 'meta') return void 0
+        else if (key === 'value' && val.type === 'Buffer') return Buffer.from(val.data).toString()
+        else return val
+      }, 2),
       meta === '{}' ? '' : 'meta: ' + meta,
     );
     return ops;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "obv": "0.0.1",
     "pull-stream": "^3.6.14",
     "rimraf": "^3.0.2",
-    "mkdirp": "^1.0.4",
     "ssb-keys": "^7.2.2",
     "ssb-ref": "^2.14.0",
     "ssb-validate": "^4.1.1",


### PR DESCRIPTION
This makes debug nicer to read by converting buffer to string. Also removes the extra mkdirp. There is an extra commit in here because I didn't push, but should be meaningless.