### PR TITLE
Fix filename encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "bipf": "^1.3.0",
     "debug": "^4.2.0",
     "idb-kv-store": "^4.5.0",
+    "jsesc": "^3.0.2",
     "lodash.debounce": "^4.0.8",
     "mkdirp": "^1.0.4",
     "push-stream": "^11.0.0",


### PR DESCRIPTION
This should fix #19.

Before the behaviour was to use [sanitize-filename](https://github.com/parshap/node-sanitize-filename) to make sure we don't end up with nasty filenames. Emojis are valid filenames at least when using utf8. But we would rather be safe so this escapes those as hex. Furthermore this also fixes a problem where sanitize filename eats some characters. So it would just strip characters like `.`, `*` and a few others, meaning a query for `hello*` would end up in the same index as `hello`.