### PR TITLE
Format code automatically with Prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "singleQuote": true
+}

--- a/copy-json-to-bipf-async.js
+++ b/copy-json-to-bipf-async.js
@@ -4,19 +4,20 @@ var AsyncFlumeLog = require('async-flumelog')
 var binary = require('bipf')
 var json = require('flumecodec/json')
 
-var block = 64*1024
+var block = 64 * 1024
 
 //copy an old (flumelog-offset) log (json) to a new async log (bipf)
 
-if(process.argv[2] === process.argv[3]) throw new Error('input must !== output')
+if (process.argv[2] === process.argv[3])
+  throw new Error('input must !== output')
 
-var log = FlumeLog(process.argv[2], {blockSize: block, codec: json})
-var log2 = AsyncFlumeLog(process.argv[3], {blockSize: block})
+var log = FlumeLog(process.argv[2], { blockSize: block, codec: json })
+var log2 = AsyncFlumeLog(process.argv[3], { blockSize: block })
 
 var dataTransferred = 0
 
 pull(
-  log.stream({seqs:false, codec: json}),
+  log.stream({ seqs: false, codec: json }),
   pull.map(function (data) {
     var len = binary.encodingLength(data)
     var b = Buffer.alloc(len)
@@ -24,17 +25,16 @@ pull(
     return b
   }),
   function (read) {
-    read(null, function next (err, data) {
-      if(err && err !== true) throw err
-      if(err) return console.error('done')
+    read(null, function next(err, data) {
+      if (err && err !== true) throw err
+      if (err) return console.error('done')
       dataTransferred += data.length
       log2.append(data, function () {})
       if (dataTransferred % block == 0)
         log2.onDrain(function () {
           read(null, next)
         })
-      else
-        read(null, next)
+      else read(null, next)
     })
   }
 )

--- a/copy-json-to-bipf-offset.js
+++ b/copy-json-to-bipf-offset.js
@@ -3,26 +3,30 @@ var FlumeLog = require('flumelog-offset')
 var binary = require('bipf')
 var json = require('flumecodec/json')
 
-var block = 64*1024
+var block = 64 * 1024
 
 //copy an old (flumelog-offset) log (json) to a new async log (bipf)
 
-if(process.argv[2] === process.argv[3]) throw new Error('input must !== output')
+if (process.argv[2] === process.argv[3])
+  throw new Error('input must !== output')
 
-var log = FlumeLog(process.argv[2], {blockSize: block, codec: json})
-var log2 = FlumeLog(process.argv[3], {blockSize: block})
+var log = FlumeLog(process.argv[2], { blockSize: block, codec: json })
+var log2 = FlumeLog(process.argv[3], { blockSize: block })
 
 pull(
-  log.stream({seqs:false, codec: json}),
+  log.stream({ seqs: false, codec: json }),
   pull.map(function (data) {
     var len = binary.encodingLength(data)
     var b = Buffer.alloc(len)
     binary.encode(data, b, 0)
     return b
   }),
-  pull.drain((data) => {
-    log2.append(data, function () {})
-  }, () => {
-    console.log("done")
-  })
+  pull.drain(
+    (data) => {
+      log2.append(data, function () {})
+    },
+    () => {
+      console.log('done')
+    }
+  )
 )

--- a/copy-json-to-bipf.js
+++ b/copy-json-to-bipf.js
@@ -4,17 +4,18 @@ var FlumeLogAligned = require('flumelog-aligned-offset')
 var binary = require('bipf')
 var json = require('flumecodec/json')
 
-var block = 64*1024
+var block = 64 * 1024
 
 //copy an old (flumelog-offset) log (json) to a new raf log (bipf)
 
-if(process.argv[2] === process.argv[3]) throw new Error('input must !== output')
+if (process.argv[2] === process.argv[3])
+  throw new Error('input must !== output')
 
-var log = FlumeLog(process.argv[2], {blockSize: block, codec: json})
-var log2 = FlumeLogAligned (process.argv[3], {block: block})
+var log = FlumeLog(process.argv[2], { blockSize: block, codec: json })
+var log2 = FlumeLogAligned(process.argv[3], { block: block })
 
 pull(
-  log.stream({seqs:false, codec: json}),
+  log.stream({ seqs: false, codec: json }),
   pull.map(function (data) {
     var len = binary.encodingLength(data)
     var b = Buffer.alloc(len)
@@ -22,16 +23,15 @@ pull(
     return b
   }),
   function (read) {
-    read(null, function next (err, data) {
-      if(err && err !== true) throw err
-      if(err) return console.error('done')
+    read(null, function next(err, data) {
+      if (err && err !== true) throw err
+      if (err) return console.error('done')
       log2.append(data, function () {})
-      if(log2.appendState.offset > log2.appendState.written + block*10)
+      if (log2.appendState.offset > log2.appendState.written + block * 10)
         log2.onDrain(function () {
           read(null, next)
         })
-      else
-        read(null, next)
+      else read(null, next)
     })
   }
 )

--- a/example.js
+++ b/example.js
@@ -1,11 +1,25 @@
 const FlumeLog = require('async-flumelog')
 const pull = require('pull-stream')
 const JITDB = require('./index')
-const {query, fromDB, and, or, slowEqual, type, debug, author, paginate, toCallback, toPromise, toPullStream, toAsyncIter} = require("./operators")
+const {
+  query,
+  fromDB,
+  and,
+  or,
+  slowEqual,
+  type,
+  debug,
+  author,
+  paginate,
+  toCallback,
+  toPromise,
+  toPullStream,
+  toAsyncIter,
+} = require('./operators')
 
-var raf = FlumeLog(process.argv[2], {blockSize: 64*1024})
+var raf = FlumeLog(process.argv[2], { blockSize: 64 * 1024 })
 
-var db = JITDB(raf, "./indexes")
+var db = JITDB(raf, './indexes')
 db.onReady(async () => {
   // seems the cache needs to be warmed up to get fast results
 
@@ -14,19 +28,20 @@ db.onReady(async () => {
   const mixy = '@G98XybiXD/amO9S/UyBKnWTWZnSKYS3YVB/5osSRHvY=.ed25519'
   const arj = '@6CAxOI3f+LUOVrbAl0IemqiS7ATpQvr9Mdw9LC4+Uv0=.ed25519'
 
-  if (true) query(
-    fromDB(db),
-    // debug(),
-    and(slowEqual('value.content.type', 'vote')),
-    // debug(),
-    and(slowEqual('value.content.vote.expression', '⛵')),
-    // debug(),
-    and(slowEqual('value.author', staltzp)),
-    // debug(),
-    toCallback((err, results) => {
-      console.log(results)
-    })
-  )
+  if (true)
+    query(
+      fromDB(db),
+      // debug(),
+      and(slowEqual('value.content.type', 'vote')),
+      // debug(),
+      and(slowEqual('value.content.vote.expression', '⛵')),
+      // debug(),
+      and(slowEqual('value.author', staltzp)),
+      // debug(),
+      toCallback((err, results) => {
+        console.log(results)
+      })
+    )
 
   if (false) {
     const results = await query(
@@ -36,31 +51,32 @@ db.onReady(async () => {
       // debug(),
       and(or(author(mix), author(mixy), author(arj))),
       // debug(),
-      toPromise(),
-    );
-    console.log(results.length);
+      toPromise()
+    )
+    console.log(results.length)
   }
 
-  var i = 0;
-  if (false) pull(
-    query(
-      fromDB(db),
-      // debug(),
-      and(type('blog')),
-      // debug(),
-      and(or(author(mix), author(mixy), author(arj))),
-      // debug(),
-      paginate(3),
-      // debug(),
-      toPullStream(),
-    ),
-    pull.drain(msgs => {
-      console.log('page #' + (i++))
-      console.log((msgs))
-    })
-  )
+  var i = 0
+  if (false)
+    pull(
+      query(
+        fromDB(db),
+        // debug(),
+        and(type('blog')),
+        // debug(),
+        and(or(author(mix), author(mixy), author(arj))),
+        // debug(),
+        paginate(3),
+        // debug(),
+        toPullStream()
+      ),
+      pull.drain((msgs) => {
+        console.log('page #' + i++)
+        console.log(msgs)
+      })
+    )
 
-  var i = 0;
+  var i = 0
   if (false) {
     const results = query(
       fromDB(db),
@@ -73,28 +89,25 @@ db.onReady(async () => {
       // debug(),
       paginate(3),
       // debug(),
-      toAsyncIter(),
+      toAsyncIter()
     )
     for await (let msgs of results) {
-      console.log('page #' + (i++))
+      console.log('page #' + i++)
       console.log(msgs)
     }
   }
 
   if (false) {
-    console.time("get all posts from users")
+    console.time('get all posts from users')
 
-    const posts = query(
-      fromDB(db),
-      and(type('post')),
-    )
+    const posts = query(fromDB(db), and(type('post')))
 
     const postsMix = query(
       posts,
       // debug(),
       and(or(author(mix), author(mixy))),
       // debug(),
-      toPromise(),
+      toPromise()
     )
 
     const postsArj = query(
@@ -102,102 +115,164 @@ db.onReady(async () => {
       // debug(),
       and(author(arj)),
       // debug(),
-      toPromise(),
+      toPromise()
     )
 
     const [resMix, resArj] = await Promise.all([postsMix, postsArj])
     console.log('mix posts: ' + resMix.length)
     console.log('arj posts: ' + resArj.length)
-    console.timeEnd("get all posts from users")
+    console.timeEnd('get all posts from users')
   }
 
   return
 
-  db.query({
-    type: 'AND',
-    data: [
-      { type: 'EQUAL', data: { seek: db.seekType, value: 'post', indexType: "type" } },
-      { type: 'EQUAL', data: { seek: db.seekAuthor, value: staltzp, indexType: "author" } }
-    ]
-  }, (err, results) => {
-    console.timeEnd("get all posts from user")
-
-    console.time("get last 10 posts from user")
-
-    db.query({
+  db.query(
+    {
       type: 'AND',
       data: [
-        { type: 'EQUAL', data: { seek: db.seekType, value: 'post', indexType: "type" } },
-        { type: 'EQUAL', data: { seek: db.seekAuthor, value: staltzp, indexType: "author" } }
-      ]
-    }, 0, 10, (err, results) => {
-      console.timeEnd("get last 10 posts from user")
+        {
+          type: 'EQUAL',
+          data: { seek: db.seekType, value: 'post', indexType: 'type' },
+        },
+        {
+          type: 'EQUAL',
+          data: { seek: db.seekAuthor, value: staltzp, indexType: 'author' },
+        },
+      ],
+    },
+    (err, results) => {
+      console.timeEnd('get all posts from user')
 
-      console.time("get top 50 posts")
+      console.time('get last 10 posts from user')
 
-      db.query({
-        type: 'EQUAL',
-        data: {
-          seek: db.seekType,
-          value: 'post',
-          indexType: "type"
-        }
-      }, 0, 50, (err, results) => {
-        console.timeEnd("get top 50 posts")
-
-        console.time("author + sequence")
-
-        db.query({
+      db.query(
+        {
           type: 'AND',
           data: [
-            { type: 'GT', data: { indexName: 'sequence', value: 7000 } },
-            { type: 'EQUAL', data: { seek: db.seekAuthor, value: staltzp, indexType: "author" } }
-          ]
-        }, (err, results) => {
-          console.timeEnd("author + sequence")
+            {
+              type: 'EQUAL',
+              data: { seek: db.seekType, value: 'post', indexType: 'type' },
+            },
+            {
+              type: 'EQUAL',
+              data: {
+                seek: db.seekAuthor,
+                value: staltzp,
+                indexType: 'author',
+              },
+            },
+          ],
+        },
+        0,
+        10,
+        (err, results) => {
+          console.timeEnd('get last 10 posts from user')
 
-          var hops = {}
-          const query = {
-            type: 'AND',
-            data: [
-              { type: 'EQUAL', data: { seek: db.seekAuthor, value: staltzp, indexType: "author" } },
-              { type: 'EQUAL', data: { seek: db.seekType, value: 'contact', indexType: "type" } }
-            ]
-          }
-          const isFeed = require('ssb-ref').isFeed
+          console.time('get top 50 posts')
 
-          console.time("contacts for author")
+          db.query(
+            {
+              type: 'EQUAL',
+              data: {
+                seek: db.seekType,
+                value: 'post',
+                indexType: 'type',
+              },
+            },
+            0,
+            50,
+            (err, results) => {
+              console.timeEnd('get top 50 posts')
 
-          db.query(query, (err, results) => {
-            results.forEach(data => {
-              var from = data.value.author
-              var to = data.value.content.contact
-              var value =
-                  data.value.content.blocking || data.value.content.flagged ? -1 :
-                  data.value.content.following === true ? 1
-                  : -2
+              console.time('author + sequence')
 
-              if(isFeed(from) && isFeed(to)) {
-                hops[from] = hops[from] || {}
-                hops[from][to] = value
-              }
-            })
+              db.query(
+                {
+                  type: 'AND',
+                  data: [
+                    {
+                      type: 'GT',
+                      data: { indexName: 'sequence', value: 7000 },
+                    },
+                    {
+                      type: 'EQUAL',
+                      data: {
+                        seek: db.seekAuthor,
+                        value: staltzp,
+                        indexType: 'author',
+                      },
+                    },
+                  ],
+                },
+                (err, results) => {
+                  console.timeEnd('author + sequence')
 
-            console.timeEnd("contacts for author")
-            //console.log(hops)
-          })
-        })
-      })
-    })
-  })
+                  var hops = {}
+                  const query = {
+                    type: 'AND',
+                    data: [
+                      {
+                        type: 'EQUAL',
+                        data: {
+                          seek: db.seekAuthor,
+                          value: staltzp,
+                          indexType: 'author',
+                        },
+                      },
+                      {
+                        type: 'EQUAL',
+                        data: {
+                          seek: db.seekType,
+                          value: 'contact',
+                          indexType: 'type',
+                        },
+                      },
+                    ],
+                  }
+                  const isFeed = require('ssb-ref').isFeed
+
+                  console.time('contacts for author')
+
+                  db.query(query, (err, results) => {
+                    results.forEach((data) => {
+                      var from = data.value.author
+                      var to = data.value.content.contact
+                      var value =
+                        data.value.content.blocking ||
+                        data.value.content.flagged
+                          ? -1
+                          : data.value.content.following === true
+                          ? 1
+                          : -2
+
+                      if (isFeed(from) && isFeed(to)) {
+                        hops[from] = hops[from] || {}
+                        hops[from][to] = value
+                      }
+                    })
+
+                    console.timeEnd('contacts for author')
+                    //console.log(hops)
+                  })
+                }
+              )
+            }
+          )
+        }
+      )
+    }
+  )
 
   return
 
-  console.time("get all")
-  db.query({
-    type: 'EQUAL',
-    data: { seek: db.seekAuthor, value: staltzp, indexType: "author" }
-  }, (err, results) => {
-    console.timeEnd("get all")
-  })
+  console.time('get all')
+  db.query(
+    {
+      type: 'EQUAL',
+      data: { seek: db.seekAuthor, value: staltzp, indexType: 'author' },
+    },
+    (err, results) => {
+      console.timeEnd('get all')
+    }
+  )
 })

--- a/index.js
+++ b/index.js
@@ -2,16 +2,16 @@ const bipf = require('bipf')
 const TypedFastBitSet = require('typedfastbitset')
 const path = require('path')
 const push = require('push-stream')
-const sanitize = require("sanitize-filename")
+const sanitize = require('sanitize-filename')
 const debounce = require('lodash.debounce')
 const AtomicFile = require('atomic-file/buffer')
 const toBuffer = require('typedarray-to-buffer')
 const bsb = require('binary-search-bounds')
-const debug = require('debug')("jitdb")
+const debug = require('debug')('jitdb')
 const jsesc = require('jsesc')
 
 module.exports = function (log, indexesPath) {
-  debug("indexes path", indexesPath)
+  debug('indexes path', indexesPath)
 
   function safeFilename(filename) {
     // in general we want to escape wierd characters
@@ -19,24 +19,23 @@ module.exports = function (log, indexesPath) {
     // sanitize will remove special characters, which means that two
     // indexes might end up with the same name so lets replace those
     // with jsesc escapeEverything values
-    result = result.replace(/\./g, "x2E")
-    result = result.replace(/\//g, "x2F")
-    result = result.replace(/\?/g, "x3F")
-    result = result.replace(/\</g, "x3C")
-    result = result.replace(/\>/g, "x3E")
-    result = result.replace(/\:/g, "x3A")
-    result = result.replace(/\*/g, "x2A")
-    result = result.replace(/\|/g, "x7C")
+    result = result.replace(/\./g, 'x2E')
+    result = result.replace(/\//g, 'x2F')
+    result = result.replace(/\?/g, 'x3F')
+    result = result.replace(/\</g, 'x3C')
+    result = result.replace(/\>/g, 'x3E')
+    result = result.replace(/\:/g, 'x3A')
+    result = result.replace(/\*/g, 'x2A')
+    result = result.replace(/\|/g, 'x7C')
     // finally sanitize
     return sanitize(result)
   }
 
   function saveTypedArray(name, seq, count, arr, cb) {
-    const filename = path.join(indexesPath, name + ".index")
-    if (!cb)
-      cb = () => {}
+    const filename = path.join(indexesPath, name + '.index')
+    if (!cb) cb = () => {}
 
-    debug("writing index to", filename)
+    debug('writing index to', filename)
 
     const dataBuffer = toBuffer(arr)
     var b = Buffer.alloc(8 + dataBuffer.length)
@@ -49,7 +48,7 @@ module.exports = function (log, indexesPath) {
   }
 
   function saveIndex(name, seq, data, cb) {
-    debug("saving index:" + name)
+    debug('saving index:' + name)
     data.trim()
     saveTypedArray(name, seq, data.count, data.words, cb)
   }
@@ -66,9 +65,11 @@ module.exports = function (log, indexesPath) {
       cb(null, {
         seq,
         count,
-        data: new Type(buf.buffer, buf.offset,
-                       buf.byteLength /
-                       (Type === Float64Array ? 8 : 4))
+        data: new Type(
+          buf.buffer,
+          buf.offset,
+          buf.byteLength / (Type === Float64Array ? 8 : 4)
+        ),
       })
     })
   }
@@ -82,7 +83,7 @@ module.exports = function (log, indexesPath) {
   }
 
   function loadLazyIndex(indexName, cb) {
-    debug("lazy loading", indexName)
+    debug('lazy loading', indexName)
     let index = indexes[indexName]
     loadIndex(index.filepath, Uint32Array, (err, i) => {
       index.seq = i.seq
@@ -100,41 +101,50 @@ module.exports = function (log, indexesPath) {
         push.asyncMap((file, cb) => {
           const indexName = path.parse(file).name
           if (file === 'offset.index') {
-            loadIndex(path.join(indexesPath, file), Uint32Array, (err, data) => {
-              indexes[indexName] = data
-              cb()
-            })
-          }
-          else if (file === 'timestamp.index') {
-            loadIndex(path.join(indexesPath, file), Float64Array, (err, data) => {
-              indexes[indexName] = data
-              cb()
-            })
-          }
-          else if (file === 'sequence.index') {
-            loadIndex(path.join(indexesPath, file), Uint32Array, (err, data) => {
-              indexes[indexName] = data
+            loadIndex(
+              path.join(indexesPath, file),
+              Uint32Array,
+              (err, data) => {
+                indexes[indexName] = data
+                cb()
+              }
+            )
+          } else if (file === 'timestamp.index') {
+            loadIndex(
+              path.join(indexesPath, file),
+              Float64Array,
+              (err, data) => {
+                indexes[indexName] = data
+                cb()
+              }
+            )
+          } else if (file === 'sequence.index') {
+            loadIndex(
+              path.join(indexesPath, file),
+              Uint32Array,
+              (err, data) => {
+                indexes[indexName] = data
 
-              cb()
-            })
-          }
-          else if (file.endsWith(".index")) {
+                cb()
+              }
+            )
+          } else if (file.endsWith('.index')) {
             indexes[indexName] = {
               seq: 0,
               data: new TypedFastBitSet(),
               lazy: true,
-              filepath: path.join(indexesPath, file)
+              filepath: path.join(indexesPath, file),
             }
 
             cb()
-          } else
-            cb()
+          } else cb()
         }),
         push.collect(cb)
       )
     }
 
-    if (typeof window !== 'undefined') { // browser
+    if (typeof window !== 'undefined') {
+      // browser
       listIndexesIDB(indexesPath, parseIndexes)
     } else {
       const fs = require('fs')
@@ -147,33 +157,32 @@ module.exports = function (log, indexesPath) {
   var isReady = false
   var waiting = []
   loadIndexes(() => {
-    debug("loaded indexes", Object.keys(indexes))
+    debug('loaded indexes', Object.keys(indexes))
 
     if (!indexes['offset']) {
       indexes['offset'] = {
         seq: 0,
         count: 0,
-        data: new Uint32Array(16 * 1000)
+        data: new Uint32Array(16 * 1000),
       }
     }
     if (!indexes['timestamp']) {
       indexes['timestamp'] = {
         seq: 0,
         count: 0,
-        data: new Float64Array(16 * 1000)
+        data: new Float64Array(16 * 1000),
       }
     }
     if (!indexes['sequence']) {
       indexes['sequence'] = {
         seq: 0,
         count: 0,
-        data: new Uint32Array(16 * 1000)
+        data: new Uint32Array(16 * 1000),
       }
     }
 
     isReady = true
-    for (var i = 0; i < waiting.length; ++i)
-      waiting[i]()
+    for (var i = 0; i < waiting.length; ++i) waiting[i]()
     waiting = []
   })
 
@@ -184,10 +193,8 @@ module.exports = function (log, indexesPath) {
   function getValue(val, cb) {
     var seq = indexes['offset'].data[val]
     log.get(seq, (err, res) => {
-      if (err && err.code === 'flumelog:deleted')
-        cb()
-      else
-        cb(err, bipf.decode(res, 0))
+      if (err && err.code === 'flumelog:deleted') cb()
+      else cb(err, bipf.decode(res, 0))
     })
   }
 
@@ -198,15 +205,13 @@ module.exports = function (log, indexesPath) {
     function s(x) {
       return {
         val: x,
-        timestamp: indexes['timestamp'].data[x]
+        timestamp: indexes['timestamp'].data[x],
       }
     }
     var timestamped = bitset.array().map(s)
     var sorted = timestamped.sort((a, b) => {
-      if (descending)
-        return b.timestamp - a.timestamp
-      else
-        return a.timestamp - b.timestamp
+      if (descending) return b.timestamp - a.timestamp
+      else return a.timestamp - b.timestamp
     })
 
     const sliced =
@@ -214,17 +219,17 @@ module.exports = function (log, indexesPath) {
         ? sorted.slice(offset, offset + limit)
         : offset > 0
         ? sorted.slice(offset)
-        : sorted;
+        : sorted
 
     push(
       push.values(sliced),
       push.asyncMap((s, cb) => getValue(s.val, cb)),
-      push.filter(x => x), // deleted messages
+      push.filter((x) => x), // deleted messages
       push.collect((err, results) => {
         cb(null, {
           data: results,
           total: timestamped.length,
-          duration: Date.now() - start
+          duration: Date.now() - start,
         })
       })
     )
@@ -234,20 +239,22 @@ module.exports = function (log, indexesPath) {
     var start = Date.now()
     return push(
       push.values(bitset.array()),
-      push.filter(val => {
+      push.filter((val) => {
         return indexes['offset'].data[val] > dbSeq
       }),
       push.asyncMap(getValue),
-      push.filter(x => x), // deleted messages
+      push.filter((x) => x), // deleted messages
       push.collect((err, results) => {
-        debug(`get all: ${Date.now()-start}ms, total items: ${results.length}`)
+        debug(
+          `get all: ${Date.now() - start}ms, total items: ${results.length}`
+        )
         cb(err, results)
       })
     )
   }
 
   function growIndex(index, Type) {
-    debug("growing index")
+    debug('growing index')
     let newArray = new Type(index.data.length * 2)
     newArray.set(index.data)
     index.data = newArray
@@ -303,18 +310,18 @@ module.exports = function (log, indexesPath) {
 
   function checkValue(opData, index, buffer) {
     const seekKey = opData.seek(buffer)
-    if (opData.value === undefined)
-      return seekKey === -1
-    else if (~seekKey && bipf.compareString(buffer, seekKey, opData.value) === 0)
+    if (opData.value === undefined) return seekKey === -1
+    else if (
+      ~seekKey &&
+      bipf.compareString(buffer, seekKey, opData.value) === 0
+    )
       return true
-    else
-      return false
+    else return false
   }
 
   function updateIndexValue(opData, index, buffer, offset) {
     const status = checkValue(opData, index, buffer)
-    if (status)
-      index.data.add(offset)
+    if (status) index.data.add(offset)
 
     return status
   }
@@ -322,12 +329,12 @@ module.exports = function (log, indexesPath) {
   function updateAllIndexValue(opData, newIndexes, buffer, offset) {
     const seekKey = opData.seek(buffer)
     const value = bipf.decode(buffer, seekKey)
-    const indexName = safeFilename(opData.indexType + "_" + value)
+    const indexName = safeFilename(opData.indexType + '_' + value)
 
     if (!newIndexes[indexName]) {
       newIndexes[indexName] = {
         seq: 0,
-        data: new TypedFastBitSet()
+        data: new TypedFastBitSet(),
       }
     }
 
@@ -349,13 +356,15 @@ module.exports = function (log, indexesPath) {
     var updatedSequenceIndex = false
     const start = Date.now()
 
-    const indexNeedsUpdate = op.data.indexName != 'sequence' && op.data.indexName != 'timestamp' && op.data.indexName != 'offset'
+    const indexNeedsUpdate =
+      op.data.indexName != 'sequence' &&
+      op.data.indexName != 'timestamp' &&
+      op.data.indexName != 'offset'
 
     log.stream({ gt: index.seq }).pipe({
       paused: false,
       write: function (data) {
-        if (updateOffsetIndex(offset, data.seq))
-          updatedOffsetIndex = true
+        if (updateOffsetIndex(offset, data.seq)) updatedOffsetIndex = true
 
         if (updateTimestampIndex(offset, data.seq, data.value))
           updatedTimestampIndex = true
@@ -370,32 +379,47 @@ module.exports = function (log, indexesPath) {
       },
       end: () => {
         var count = offset // incremented at end
-        debug(`time: ${Date.now()-start}ms, total items: ${count}`)
+        debug(`time: ${Date.now() - start}ms, total items: ${count}`)
 
         if (updatedOffsetIndex)
-          saveTypedArray('offset', indexes['offset'].seq, count, indexes['offset'].data)
+          saveTypedArray(
+            'offset',
+            indexes['offset'].seq,
+            count,
+            indexes['offset'].data
+          )
 
         if (updatedTimestampIndex)
-          saveTypedArray('timestamp', indexes['timestamp'].seq, count, indexes['timestamp'].data)
+          saveTypedArray(
+            'timestamp',
+            indexes['timestamp'].seq,
+            count,
+            indexes['timestamp'].data
+          )
 
         if (updatedSequenceIndex)
-          saveTypedArray('sequence', indexes['sequence'].seq, count, indexes['sequence'].data)
+          saveTypedArray(
+            'sequence',
+            indexes['sequence'].seq,
+            count,
+            indexes['sequence'].data
+          )
 
         index.seq = indexes['offset'].seq
         if (indexNeedsUpdate)
           saveIndex(op.data.indexName, index.seq, index.data)
 
         cb()
-      }
+      },
     })
   }
 
   function createIndexes(missingIndexes, cb) {
     var newIndexes = {}
-    missingIndexes.forEach(m => {
+    missingIndexes.forEach((m) => {
       newIndexes[m.indexName] = {
         seq: 0,
-        data: new TypedFastBitSet()
+        data: new TypedFastBitSet(),
       }
     })
 
@@ -412,8 +436,7 @@ module.exports = function (log, indexesPath) {
         var seq = data.seq
         var buffer = data.value
 
-        if (updateOffsetIndex(offset, seq))
-          updatedOffsetIndex = true
+        if (updateOffsetIndex(offset, seq)) updatedOffsetIndex = true
 
         if (updateTimestampIndex(offset, data.seq, buffer))
           updatedTimestampIndex = true
@@ -421,27 +444,40 @@ module.exports = function (log, indexesPath) {
         if (updateSequenceIndex(offset, data.seq, data.value))
           updatedSequenceIndex = true
 
-        missingIndexes.forEach(m => {
-          if (m.indexAll)
-            updateAllIndexValue(m, newIndexes, buffer, offset)
-          else
-            updateIndexValue(m, newIndexes[m.indexName], buffer, offset)
+        missingIndexes.forEach((m) => {
+          if (m.indexAll) updateAllIndexValue(m, newIndexes, buffer, offset)
+          else updateIndexValue(m, newIndexes[m.indexName], buffer, offset)
         })
 
         offset++
       },
       end: () => {
         var count = offset // incremented at end
-        debug(`time: ${Date.now()-start}ms, total items: ${count}`)
+        debug(`time: ${Date.now() - start}ms, total items: ${count}`)
 
         if (updatedOffsetIndex)
-          saveTypedArray('offset', indexes['offset'].seq, count, indexes['offset'].data)
+          saveTypedArray(
+            'offset',
+            indexes['offset'].seq,
+            count,
+            indexes['offset'].data
+          )
 
         if (updatedTimestampIndex)
-          saveTypedArray('timestamp', indexes['timestamp'].seq, count, indexes['timestamp'].data)
+          saveTypedArray(
+            'timestamp',
+            indexes['timestamp'].seq,
+            count,
+            indexes['timestamp'].data
+          )
 
         if (updatedSequenceIndex)
-          saveTypedArray('sequence', indexes['sequence'].seq, count, indexes['sequence'].data)
+          saveTypedArray(
+            'sequence',
+            indexes['sequence'].seq,
+            count,
+            indexes['sequence'].data
+          )
 
         for (var indexName in newIndexes) {
           indexes[indexName] = newIndexes[indexName]
@@ -450,7 +486,7 @@ module.exports = function (log, indexesPath) {
         }
 
         cb()
-      }
+      },
     })
   }
 
@@ -465,10 +501,12 @@ module.exports = function (log, indexesPath) {
   function setupIndex(op) {
     if (!op.data.indexName) {
       const name = op.data.value === undefined ? '' : op.data.value.toString()
-      op.data.indexName = safeFilename(op.data.indexType + "_" + name)
+      op.data.indexName = safeFilename(op.data.indexType + '_' + name)
     }
     if (op.data.value !== undefined)
-      op.data.value = Buffer.isBuffer(op.data.value) ? op.data.value : Buffer.from(op.data.value)
+      op.data.value = Buffer.isBuffer(op.data.value)
+        ? op.data.value
+        : Buffer.from(op.data.value)
   }
 
   function indexSync(operation, cb) {
@@ -476,51 +514,40 @@ module.exports = function (log, indexesPath) {
     var lazyIndexes = []
 
     function handleOperations(ops) {
-      ops.forEach(op => {
+      ops.forEach((op) => {
         if (op.type === 'EQUAL') {
           setupIndex(op)
-          if (!indexes[op.data.indexName])
-            missingIndexes.push(op.data)
+          if (!indexes[op.data.indexName]) missingIndexes.push(op.data)
           else if (indexes[op.data.indexName].lazy)
             lazyIndexes.push(op.data.indexName)
-        }
-        else if (op.type === 'AND' || op.type === 'OR')
+        } else if (op.type === 'AND' || op.type === 'OR')
           handleOperations(op.data)
-        else if (op.type === 'OFFSETS' || op.type === 'SEQS')
-          ;
-        else
-          debug("Unknown operator type:" + op.type)
+        else if (op.type === 'OFFSETS' || op.type === 'SEQS');
+        else debug('Unknown operator type:' + op.type)
       })
     }
 
     handleOperations([operation])
 
-    if (missingIndexes.length > 0)
-      debug("missing indexes:", missingIndexes)
+    if (missingIndexes.length > 0) debug('missing indexes:', missingIndexes)
 
     function ensureIndexSync(op, cb) {
-      if (log.since.value > indexes[op.data.indexName].seq)
-        updateIndex(op, cb)
-      else
-        cb()
+      if (log.since.value > indexes[op.data.indexName].seq) updateIndex(op, cb)
+      else cb()
     }
 
     function filterIndex(op, filterCheck, cb) {
       ensureIndexSync(op, () => {
         if (op.data.indexName == 'sequence') {
           let t = new TypedFastBitSet()
-          for (var i = 0; i < indexes['sequence'].count; ++i)
-          {
-            if (filterCheck(indexes['sequence'].data[i], op))
-              t.add(i)
+          for (var i = 0; i < indexes['sequence'].count; ++i) {
+            if (filterCheck(indexes['sequence'].data[i], op)) t.add(i)
           }
           cb(t)
         } else if (op.data.indexName == 'timestamp') {
           let t = new TypedFastBitSet()
-          for (var i = 0; i < indexes['timestamp'].count; ++i)
-          {
-            if (filterCheck(indexes['timestamp'].data[i], op))
-              t.add(i)
+          for (var i = 0; i < indexes['timestamp'].count; ++i) {
+            if (filterCheck(indexes['timestamp'].data[i], op)) t.add(i)
           }
           cb(t)
         }
@@ -530,10 +557,10 @@ module.exports = function (log, indexesPath) {
     function nestLargeArray(ops, type) {
       let op = ops[0]
 
-      ops.slice(1).forEach(r => {
+      ops.slice(1).forEach((r) => {
         op = {
           type,
-          data: [op, r]
+          data: [op, r],
         }
       })
 
@@ -543,8 +570,7 @@ module.exports = function (log, indexesPath) {
     function ensureOffsetIndexSync(cb) {
       if (log.since.value > indexes['offset'].seq)
         updateIndex({ data: { indexName: 'offset' } }, cb)
-      else
-        cb()
+      else cb()
     }
 
     function getBitsetForOperation(op, cb) {
@@ -552,68 +578,52 @@ module.exports = function (log, indexesPath) {
         ensureIndexSync(op, () => {
           cb(indexes[op.data.indexName].data)
         })
-      }
-      else if (op.type === 'GT') {
+      } else if (op.type === 'GT') {
         filterIndex(op, (d, op) => d > op.data.value, cb)
-      }
-      else if (op.type === 'GTE') {
+      } else if (op.type === 'GTE') {
         filterIndex(op, (d, op) => d >= op.data.value, cb)
-      }
-      else if (op.type === 'LT') {
+      } else if (op.type === 'LT') {
         filterIndex(op, (d, op) => d < op.data.value, cb)
-      }
-      else if (op.type === 'LTE') {
+      } else if (op.type === 'LTE') {
         filterIndex(op, (d, op) => d <= op.data.value, cb)
-      }
-      else if (op.type === 'SEQS') {
+      } else if (op.type === 'SEQS') {
         ensureOffsetIndexSync(() => {
           var offsets = []
-          op.seqs.sort((x,y) => x-y)
-          for (var o = 0; o < indexes['offset'].data.length; ++o)
-          {
+          op.seqs.sort((x, y) => x - y)
+          for (var o = 0; o < indexes['offset'].data.length; ++o) {
             if (bsb.eq(op.seqs, indexes['offset'].data[o]) != -1)
               offsets.push(o)
 
-            if (offsets.length == op.seqs.length)
-              break
+            if (offsets.length == op.seqs.length) break
           }
           cb(new TypedFastBitSet(offsets))
         })
-      }
-      else if (op.type === 'OFFSETS') {
+      } else if (op.type === 'OFFSETS') {
         ensureOffsetIndexSync(() => {
           cb(new TypedFastBitSet(op.offsets))
         })
-      }
-      else if (op.type === 'AND')
-      {
-        if (op.data.length > 2)
-          op = nestLargeArray(op.data, 'AND')
+      } else if (op.type === 'AND') {
+        if (op.data.length > 2) op = nestLargeArray(op.data, 'AND')
 
         getBitsetForOperation(op.data[0], (op1) => {
           getBitsetForOperation(op.data[1], (op2) => {
             cb(op1.new_intersection(op2))
           })
         })
-      }
-      else if (op.type === 'OR')
-      {
-        if (op.data.length > 2)
-          op = nestLargeArray(op.data, 'OR')
+      } else if (op.type === 'OR') {
+        if (op.data.length > 2) op = nestLargeArray(op.data, 'OR')
 
         getBitsetForOperation(op.data[0], (op1) => {
           getBitsetForOperation(op.data[1], (op2) => {
             cb(op1.new_union(op2))
           })
         })
-      }
-      else if (!op.type) {
+      } else if (!op.type) {
         getBitsetForOperation(
-          {type: 'GTE', data: {indexName: 'sequence', value: 0}},
-          cb,
-        );
-      } else
-        console.error("Unknown type", op)
+          { type: 'GTE', data: { indexName: 'sequence', value: 0 } },
+          cb
+        )
+      } else console.error('Unknown type', op)
     }
 
     function step3() {
@@ -621,56 +631,63 @@ module.exports = function (log, indexesPath) {
     }
 
     function step2() {
-      if (missingIndexes.length > 0)
-        createIndexes(missingIndexes, step3)
-      else
-        step3()
+      if (missingIndexes.length > 0) createIndexes(missingIndexes, step3)
+      else step3()
     }
 
-    if (lazyIndexes.length > 0)
-      loadLazyIndexes(lazyIndexes, step2)
-    else
-      step2()
+    if (lazyIndexes.length > 0) loadLazyIndexes(lazyIndexes, step2)
+    else step2()
   }
 
   function onReady(cb) {
-    if (isReady)
-      cb()
+    if (isReady) cb()
     else waiting.push(cb)
   }
 
   return Object.assign({
-    paginate: function(operation, offset, limit, descending, cb) {
+    paginate: function (operation, offset, limit, descending, cb) {
       onReady(() => {
-        indexSync(operation, bitset => {
-          getValuesFromBitsetSlice(bitset, offset, limit, descending, (err, res) => {
-            if (err) cb(err)
-            else {
-              debug(`getTop: ${res.duration}ms, items: ${res.length}`)
-              cb(err, res)
+        indexSync(operation, (bitset) => {
+          getValuesFromBitsetSlice(
+            bitset,
+            offset,
+            limit,
+            descending,
+            (err, res) => {
+              if (err) cb(err)
+              else {
+                debug(`getTop: ${res.duration}ms, items: ${res.length}`)
+                cb(err, res)
+              }
             }
-          })
+          )
         })
       })
     },
 
-    all: function(operation, offset, descending, cb) {
+    all: function (operation, offset, descending, cb) {
       onReady(() => {
-        indexSync(operation, bitset => {
-          getValuesFromBitsetSlice(bitset, offset, null, descending, (err, res) => {
-            if (err) cb(err)
-            else {
-              debug(`getAll: ${res.duration}ms, total items: ${res.length}`)
-              cb(err, res.data)
+        indexSync(operation, (bitset) => {
+          getValuesFromBitsetSlice(
+            bitset,
+            offset,
+            null,
+            descending,
+            (err, res) => {
+              if (err) cb(err)
+              else {
+                debug(`getAll: ${res.duration}ms, total items: ${res.length}`)
+                cb(err, res.data)
+              }
             }
-          })
+          )
         })
       })
     },
 
-    querySeq: function(operation, seq, cb) {
+    querySeq: function (operation, seq, cb) {
       onReady(() => {
-        indexSync(operation, data => {
+        indexSync(operation, (data) => {
           getLargerThanSeq(data, seq, cb)
         })
       })
@@ -680,9 +697,9 @@ module.exports = function (log, indexesPath) {
       return indexes[op.data.indexName].seq
     },
 
-    liveQuerySingleIndex: function(op, cb) {
+    liveQuerySingleIndex: function (op, cb) {
       var newValues = []
-      var sendNewValues = debounce(function() {
+      var sendNewValues = debounce(function () {
         var v = newValues.slice(0)
         newValues = []
         cb(null, v)
@@ -698,15 +715,14 @@ module.exports = function (log, indexesPath) {
       var opts = { live: true }
 
       var index = indexes[op.data.indexName]
-      if (index)
-        opts.gt = index.seq
+      if (index) opts.gt = index.seq
 
       log.stream(opts).pipe({
         paused: false,
         write: function (data) {
           if (checkValue(op.data, index, data.value))
             syncNewValue(bipf.decode(data.value, 0))
-        }
+        },
       })
     },
 
@@ -716,6 +732,6 @@ module.exports = function (log, indexesPath) {
     saveIndex,
     saveTypedArray,
     loadIndex,
-    indexes
+    indexes,
   })
 }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,11 @@
     "async-flumelog": "^1.0.6",
     "flumecodec": "0.0.1",
     "flumelog-offset": "3.4.4",
+    "husky": "^4.3.0",
     "mkdirp": "^1.0.4",
     "obv": "0.0.1",
+    "prettier": "^2.1.2",
+    "pretty-quick": "^3.1.0",
     "pull-stream": "^3.6.14",
     "rimraf": "^3.0.2",
     "ssb-keys": "^7.2.2",
@@ -38,7 +41,14 @@
     "tape": "^5.0.1"
   },
   "scripts": {
-    "test": "tape test/*.js | tap-spec"
+    "test": "tape test/*.js | tap-spec",
+    "format-code": "prettier --write \"*.js\" \"test/*.js\"",
+    "format-code-staged": "pretty-quick --staged --pattern \"*.js\" --pattern \"test/*.js\""
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm run format-code-staged"
+    }
   },
   "author": "Anders Rune Jensen <arj03@protonmail.ch>",
   "contributors": ["Andre Staltz <contact@staltz.com>"],

--- a/test/add.js
+++ b/test/add.js
@@ -26,8 +26,8 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
     data: {
       seek: helpers.seekType,
       value: 'post',
-      indexType: "type"
-    }
+      indexType: 'type',
+    },
   }
 
   addMsg(state.queue[0].value, raf, (err, msg1) => {
@@ -49,8 +49,8 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
               data: {
                 seek: helpers.seekAuthor,
                 value: keys.id,
-                indexType: "author"
-              }
+                indexType: 'author',
+              },
             }
             db.paginate(authorQuery, 0, 10, false, (err, results) => {
               t.equal(results.data.length, 1)
@@ -61,33 +61,48 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
                 t.equal(results.data.length, 1)
                 t.equal(results.data[0].id, msg1.id)
 
-                db.paginate({
-                  type: 'AND',
-                  data: [authorQuery, typeQuery]
-                }, 0, 10, false, (err, results) => {
-                  t.equal(results.data.length, 1)
-                  t.equal(results.data[0].id, msg1.id)
-
-                  const authorQuery2 = {
-                    type: 'EQUAL',
-                    data: {
-                      seek: helpers.seekAuthor,
-                      value: keys2.id,
-                      indexType: "author"
-                    }
-                  }
-
-                  db.paginate({
+                db.paginate(
+                  {
                     type: 'AND',
-                    data: [typeQuery, {
-                      type: 'OR',
-                      data: [authorQuery, authorQuery2]
-                    }]
-                  }, 0, 10, false, (err, results) => {
-                    t.equal(results.data.length, 2)
-                    t.end()
-                  })
-                })
+                    data: [authorQuery, typeQuery],
+                  },
+                  0,
+                  10,
+                  false,
+                  (err, results) => {
+                    t.equal(results.data.length, 1)
+                    t.equal(results.data[0].id, msg1.id)
+
+                    const authorQuery2 = {
+                      type: 'EQUAL',
+                      data: {
+                        seek: helpers.seekAuthor,
+                        value: keys2.id,
+                        indexType: 'author',
+                      },
+                    }
+
+                    db.paginate(
+                      {
+                        type: 'AND',
+                        data: [
+                          typeQuery,
+                          {
+                            type: 'OR',
+                            data: [authorQuery, authorQuery2],
+                          },
+                        ],
+                      },
+                      0,
+                      10,
+                      false,
+                      (err, results) => {
+                        t.equal(results.data.length, 2)
+                        t.end()
+                      }
+                    )
+                  }
+                )
               })
             })
           })
@@ -108,8 +123,8 @@ prepareAndRunTest('Update index', dir, (t, db, raf) => {
     data: {
       seek: helpers.seekType,
       value: 'post',
-      indexType: "type"
-    }
+      indexType: 'type',
+    },
   }
 
   addMsg(state.queue[0].value, raf, (err, msg1) => {
@@ -131,7 +146,7 @@ prepareAndRunTest('grow', dir, (t, db, raf) => {
 
   let state = validate.initial()
   for (var i = 0; i < 32 * 1000; ++i) {
-    msg.text = "Testing " + i
+    msg.text = 'Testing ' + i
     state = validate.appendNew(state, null, keys, msg, Date.now())
   }
 
@@ -140,8 +155,8 @@ prepareAndRunTest('grow', dir, (t, db, raf) => {
     data: {
       seek: helpers.seekType,
       value: 'post',
-      indexType: "type"
-    }
+      indexType: 'type',
+    },
   }
 
   push(
@@ -173,22 +188,24 @@ prepareAndRunTest('indexAll', dir, (t, db, raf) => {
   const authorQuery = {
     type: 'AND',
     data: [
-      { type: 'EQUAL',
+      {
+        type: 'EQUAL',
         data: {
           seek: helpers.seekType,
           value: 'post',
-          indexType: "type"
-        }
+          indexType: 'type',
+        },
       },
-      { type: 'EQUAL',
+      {
+        type: 'EQUAL',
         data: {
           seek: helpers.seekAuthor,
           value: keys.id,
-          indexType: "author",
-          indexAll: true
-        }
-      }
-    ]
+          indexType: 'author',
+          indexAll: true,
+        },
+      },
+    ],
   }
 
   addMsg(state.queue[0].value, raf, (err, msg) => {
@@ -198,7 +215,7 @@ prepareAndRunTest('indexAll', dir, (t, db, raf) => {
           db.all(authorQuery, 0, false, (err, results) => {
             t.equal(results.length, 1)
             t.equal(results[0].value.content.text, 'Testing 1')
-            t.equal(Object.keys(db.indexes).length, 3+2+1+1)
+            t.equal(Object.keys(db.indexes).length, 3 + 2 + 1 + 1)
             t.end()
           })
         })
@@ -224,9 +241,9 @@ prepareAndRunTest('indexAll multiple reindexes', dir, (t, db, raf) => {
       data: {
         seek: helpers.seekType,
         value,
-        indexType: "type",
-        indexAll: true
-      }
+        indexType: 'type',
+        indexAll: true,
+      },
     }
   }
 

--- a/test/common.js
+++ b/test/common.js
@@ -9,15 +9,15 @@ const helpers = require('./helpers')
 
 module.exports = function () {
   function getId(msg) {
-    return '%'+hash(JSON.stringify(msg, null, 2))
+    return '%' + hash(JSON.stringify(msg, null, 2))
   }
 
   return {
-    addMsg: function(msg, raf, cb) {
+    addMsg: function (msg, raf, cb) {
       var data = {
         key: getId(msg),
         value: msg,
-        timestamp: Date.now()
+        timestamp: Date.now(),
       }
       var b = Buffer.alloc(bipf.encodingLength(data))
       bipf.encode(data, b, 0)
@@ -29,11 +29,10 @@ module.exports = function () {
       })
     },
 
-    prepareAndRunTest: function(name, dir, cb)
-    {
+    prepareAndRunTest: function (name, dir, cb) {
       fs.closeSync(fs.openSync(path.join(dir, name), 'w')) // touch
-      let raf = FlumeLog(path.join(dir, name), { blockSize: 64*1024 })
-      let db = jitdb(raf, path.join(dir, "indexes" + name))
+      let raf = FlumeLog(path.join(dir, name), { blockSize: 64 * 1024 })
+      let db = jitdb(raf, path.join(dir, 'indexes' + name))
       db.onReady(() => {
         test(name, (t) => cb(t, db, raf))
       })

--- a/test/del.js
+++ b/test/del.js
@@ -26,8 +26,8 @@ prepareAndRunTest('Delete', dir, (t, db, raf) => {
     data: {
       seek: helpers.seekType,
       value: 'post',
-      indexType: "type"
-    }
+      indexType: 'type',
+    },
   }
 
   addMsg(state.queue[0].value, raf, (err, msg1) => {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -10,55 +10,50 @@ const bPrivate = Buffer.from('private')
 const bChannel = Buffer.from('channel')
 
 module.exports = {
-  seekAuthor: function(buffer) {
+  seekAuthor: function (buffer) {
     var p = 0 // note you pass in p!
     p = bipf.seekKey(buffer, p, bValue)
 
-    if (~p)
-      return bipf.seekKey(buffer, p, bAuthor)
+    if (~p) return bipf.seekKey(buffer, p, bAuthor)
   },
 
-  seekType: function(buffer) {
-    var p = 0 // note you pass in p!
-    p = bipf.seekKey(buffer, p, bValue)
-
-    if (~p) {
-      p = bipf.seekKey(buffer, p, bContent)
-      if (~p)
-        return bipf.seekKey(buffer, p, bType)
-    }
-  },
-
-  seekRoot: function(buffer) {
+  seekType: function (buffer) {
     var p = 0 // note you pass in p!
     p = bipf.seekKey(buffer, p, bValue)
 
     if (~p) {
       p = bipf.seekKey(buffer, p, bContent)
-      if (~p)
-        return bipf.seekKey(buffer, p, bRoot)
+      if (~p) return bipf.seekKey(buffer, p, bType)
     }
   },
 
-  seekPrivate: function(buffer) {
+  seekRoot: function (buffer) {
+    var p = 0 // note you pass in p!
+    p = bipf.seekKey(buffer, p, bValue)
+
+    if (~p) {
+      p = bipf.seekKey(buffer, p, bContent)
+      if (~p) return bipf.seekKey(buffer, p, bRoot)
+    }
+  },
+
+  seekPrivate: function (buffer) {
     var p = 0 // note you pass in p!
     p = bipf.seekKey(buffer, p, bValue)
 
     if (~p) {
       p = bipf.seekKey(buffer, p, bMeta)
-      if (~p)
-        return bipf.seekKey(buffer, p, bPrivate)
+      if (~p) return bipf.seekKey(buffer, p, bPrivate)
     }
   },
 
-  seekChannel: function(buffer) {
+  seekChannel: function (buffer) {
     var p = 0 // note you pass in p!
     p = bipf.seekKey(buffer, p, bValue)
 
     if (~p) {
       p = bipf.seekKey(buffer, p, bContent)
-      if (~p)
-        return bipf.seekKey(buffer, p, bChannel)
+      if (~p) return bipf.seekKey(buffer, p, bChannel)
     }
-  }
+  },
 }

--- a/test/live.js
+++ b/test/live.js
@@ -24,19 +24,17 @@ prepareAndRunTest('Live', dir, (t, db, raf) => {
     data: {
       seek: helpers.seekType,
       value: 'post',
-      indexType: "type"
-    }
+      indexType: 'type',
+    },
   }
 
   var i = 1
   db.liveQuerySingleIndex(typeQuery, (err, results) => {
-    if (i++ == 1)
-    {
+    if (i++ == 1) {
       t.equal(results.length, 1)
       t.equal(results[0].id, state.queue[0].value.id)
       addMsg(state.queue[1].value, raf, (err, msg1) => {})
-    }
-    else {
+    } else {
       t.equal(results.length, 1)
       t.equal(results[0].id, state.queue[1].value.id)
       t.end()
@@ -59,8 +57,8 @@ prepareAndRunTest('Live with initial values', dir, (t, db, raf) => {
     data: {
       seek: helpers.seekType,
       value: 'post',
-      indexType: "type"
-    }
+      indexType: 'type',
+    },
   }
 
   addMsg(state.queue[0].value, raf, (err, msg1) => {

--- a/test/operators.js
+++ b/test/operators.js
@@ -1,10 +1,10 @@
-const test = require('tape');
-const pull = require('pull-stream');
-const validate = require('ssb-validate');
-const ssbKeys = require('ssb-keys');
-const {prepareAndRunTest, addMsg, helpers} = require('./common')();
-const rimraf = require('rimraf');
-const mkdirp = require('mkdirp');
+const test = require('tape')
+const pull = require('pull-stream')
+const validate = require('ssb-validate')
+const ssbKeys = require('ssb-keys')
+const { prepareAndRunTest, addMsg, helpers } = require('./common')()
+const rimraf = require('rimraf')
+const mkdirp = require('mkdirp')
 const {
   query,
   and,
@@ -26,122 +26,111 @@ const {
   toPromise,
   toPullStream,
   toAsyncIter,
-} = require('../operators');
+} = require('../operators')
 
-const dir = '/tmp/jitdb-query-api';
-rimraf.sync(dir);
-mkdirp.sync(dir);
+const dir = '/tmp/jitdb-query-api'
+rimraf.sync(dir)
+mkdirp.sync(dir)
 
-const alice = ssbKeys.generate('ed25519', Buffer.alloc(32, 'a'));
-const bob = ssbKeys.generate('ed25519', Buffer.alloc(32, 'b'));
+const alice = ssbKeys.generate('ed25519', Buffer.alloc(32, 'a'))
+const bob = ssbKeys.generate('ed25519', Buffer.alloc(32, 'b'))
 
 prepareAndRunTest('operators API supports equal', dir, (t, db, raf) => {
   const queryTree = query(
     fromDB(db),
-    and(equal(helpers.seekType, 'post', 'type', true)),
-  );
+    and(equal(helpers.seekType, 'post', 'type', true))
+  )
 
-  t.equal(typeof queryTree, 'object', 'queryTree is an object');
+  t.equal(typeof queryTree, 'object', 'queryTree is an object')
 
-  t.equal(queryTree.type, 'EQUAL');
+  t.equal(queryTree.type, 'EQUAL')
 
-  t.equal(queryTree.data.indexType, 'type');
-  t.equal(queryTree.data.indexAll, true);
-  t.deepEqual(queryTree.data.value, Buffer.from('post'));
-  t.true(queryTree.data.seek.toString().includes('bipf.seekKey'));
+  t.equal(queryTree.data.indexType, 'type')
+  t.equal(queryTree.data.indexAll, true)
+  t.deepEqual(queryTree.data.value, Buffer.from('post'))
+  t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
 
-  t.equal(typeof queryTree.meta, 'object', 'queryTree contains meta');
-  t.equal(typeof queryTree.meta.db, 'object', 'queryTree contains meta.db');
-  t.equal(
-    typeof queryTree.meta.db.onReady,
-    'function',
-    'meta.db looks correct',
-  );
+  t.equal(typeof queryTree.meta, 'object', 'queryTree contains meta')
+  t.equal(typeof queryTree.meta.db, 'object', 'queryTree contains meta.db')
+  t.equal(typeof queryTree.meta.db.onReady, 'function', 'meta.db looks correct')
 
-  t.end();
-});
+  t.end()
+})
 
 prepareAndRunTest('operators API supports slowEqual', dir, (t, db, raf) => {
   const queryTree = query(
     fromDB(db),
-    and(slowEqual('value.content.type', 'post')),
-  );
+    and(slowEqual('value.content.type', 'post'))
+  )
 
-  t.equal(typeof queryTree, 'object', 'queryTree is an object');
+  t.equal(typeof queryTree, 'object', 'queryTree is an object')
 
-  t.equal(queryTree.type, 'EQUAL');
+  t.equal(queryTree.type, 'EQUAL')
 
-  t.equal(queryTree.data.indexType, 'value_content_type');
-  t.notOk(queryTree.data.indexAll);
-  t.deepEqual(queryTree.data.value, Buffer.from('post'));
-  t.true(queryTree.data.seek.toString().includes('bipf.seekKey'));
+  t.equal(queryTree.data.indexType, 'value_content_type')
+  t.notOk(queryTree.data.indexAll)
+  t.deepEqual(queryTree.data.value, Buffer.from('post'))
+  t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
 
-  t.equal(typeof queryTree.meta, 'object', 'queryTree contains meta');
-  t.equal(typeof queryTree.meta.db, 'object', 'queryTree contains meta.db');
-  t.equal(
-    typeof queryTree.meta.db.onReady,
-    'function',
-    'meta.db looks correct',
-  );
+  t.equal(typeof queryTree.meta, 'object', 'queryTree contains meta')
+  t.equal(typeof queryTree.meta.db, 'object', 'queryTree contains meta.db')
+  t.equal(typeof queryTree.meta.db.onReady, 'function', 'meta.db looks correct')
 
-  t.end();
-});
+  t.end()
+})
 
 prepareAndRunTest('slowEqual 3 args', dir, (t, db, raf) => {
   const queryTree = slowEqual('value.content.type', 'post', true)
 
-  t.equal(typeof queryTree, 'object', 'queryTree is an object');
+  t.equal(typeof queryTree, 'object', 'queryTree is an object')
 
-  t.equal(queryTree.type, 'EQUAL');
+  t.equal(queryTree.type, 'EQUAL')
 
-  t.equal(queryTree.data.indexType, 'value_content_type');
-  t.equal(queryTree.data.indexAll, true);
-  t.deepEqual(queryTree.data.value, Buffer.from('post'));
-  t.true(queryTree.data.seek.toString().includes('bipf.seekKey'));
+  t.equal(queryTree.data.indexType, 'value_content_type')
+  t.equal(queryTree.data.indexAll, true)
+  t.deepEqual(queryTree.data.value, Buffer.from('post'))
+  t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
 
-  t.end();
-});
+  t.end()
+})
 
 prepareAndRunTest('operators API supports and or', dir, (t, db, raf) => {
   const queryTree = query(
     fromDB(db),
     and(slowEqual('value.content.type', 'post')),
     and(
-      or(
-        slowEqual('value.author', alice.id),
-        slowEqual('value.author', bob.id)
-      )
-    ),
-  );
+      or(slowEqual('value.author', alice.id), slowEqual('value.author', bob.id))
+    )
+  )
 
-  t.equal(typeof queryTree, 'object', 'queryTree is an object');
+  t.equal(typeof queryTree, 'object', 'queryTree is an object')
 
-  t.equal(queryTree.type, 'AND');
-  t.true(Array.isArray(queryTree.data), '.data is an array');
+  t.equal(queryTree.type, 'AND')
+  t.true(Array.isArray(queryTree.data), '.data is an array')
 
-  t.equal(queryTree.data[0].type, 'EQUAL');
-  t.equal(queryTree.data[0].data.indexType, 'value_content_type');
-  t.deepEqual(queryTree.data[0].data.value, Buffer.from('post'));
+  t.equal(queryTree.data[0].type, 'EQUAL')
+  t.equal(queryTree.data[0].data.indexType, 'value_content_type')
+  t.deepEqual(queryTree.data[0].data.value, Buffer.from('post'))
 
-  t.equal(queryTree.data[1].type, 'OR');
-  t.true(Array.isArray(queryTree.data[1].data), '.data[1].data is an array');
+  t.equal(queryTree.data[1].type, 'OR')
+  t.true(Array.isArray(queryTree.data[1].data), '.data[1].data is an array')
 
-  t.equal(queryTree.data[1].data[0].type, 'EQUAL');
-  t.deepEqual(queryTree.data[1].data[0].data.indexType, 'value_author');
-  t.deepEqual(queryTree.data[1].data[0].data.value, Buffer.from(alice.id));
+  t.equal(queryTree.data[1].data[0].type, 'EQUAL')
+  t.deepEqual(queryTree.data[1].data[0].data.indexType, 'value_author')
+  t.deepEqual(queryTree.data[1].data[0].data.value, Buffer.from(alice.id))
   t.true(
-    queryTree.data[1].data[0].data.seek.toString().includes('bipf.seekKey'),
-  );
+    queryTree.data[1].data[0].data.seek.toString().includes('bipf.seekKey')
+  )
 
-  t.equal(queryTree.data[1].data[1].type, 'EQUAL');
-  t.equal(queryTree.data[1].data[1].data.indexType, 'value_author');
-  t.deepEqual(queryTree.data[1].data[1].data.value, Buffer.from(bob.id));
+  t.equal(queryTree.data[1].data[1].type, 'EQUAL')
+  t.equal(queryTree.data[1].data[1].data.indexType, 'value_author')
+  t.deepEqual(queryTree.data[1].data[1].data.value, Buffer.from(bob.id))
   t.true(
-    queryTree.data[1].data[1].data.seek.toString().includes('bipf.seekKey'),
-  );
+    queryTree.data[1].data[1].data.seek.toString().includes('bipf.seekKey')
+  )
 
-  t.end();
-});
+  t.end()
+})
 
 prepareAndRunTest('operators multi and', dir, (t, db, raf) => {
   const queryTree = query(
@@ -150,20 +139,20 @@ prepareAndRunTest('operators multi and', dir, (t, db, raf) => {
       slowEqual('value.content.type', 'post'),
       slowEqual('value.author', alice.id),
       slowEqual('value.author', bob.id)
-    ),
-  );
+    )
+  )
 
-  t.equal(typeof queryTree, 'object', 'queryTree is an object');
+  t.equal(typeof queryTree, 'object', 'queryTree is an object')
 
-  t.equal(queryTree.type, 'AND');
-  t.true(Array.isArray(queryTree.data), '.data is an array');
+  t.equal(queryTree.type, 'AND')
+  t.true(Array.isArray(queryTree.data), '.data is an array')
 
-  t.equal(queryTree.data[0].type, 'EQUAL');
-  t.equal(queryTree.data[1].type, 'EQUAL');
-  t.equal(queryTree.data[2].type, 'EQUAL');
+  t.equal(queryTree.data[0].type, 'EQUAL')
+  t.equal(queryTree.data[1].type, 'EQUAL')
+  t.equal(queryTree.data[2].type, 'EQUAL')
 
-  t.end();
-});
+  t.end()
+})
 
 prepareAndRunTest('operators multi or', dir, (t, db, raf) => {
   const queryTree = query(
@@ -172,20 +161,20 @@ prepareAndRunTest('operators multi or', dir, (t, db, raf) => {
       slowEqual('value.content.type', 'post'),
       slowEqual('value.author', alice.id),
       slowEqual('value.author', bob.id)
-    ),
-  );
+    )
+  )
 
-  t.equal(typeof queryTree, 'object', 'queryTree is an object');
+  t.equal(typeof queryTree, 'object', 'queryTree is an object')
 
-  t.equal(queryTree.type, 'OR');
-  t.true(Array.isArray(queryTree.data), '.data is an array');
+  t.equal(queryTree.type, 'OR')
+  t.true(Array.isArray(queryTree.data), '.data is an array')
 
-  t.equal(queryTree.data[0].type, 'EQUAL');
-  t.equal(queryTree.data[1].type, 'EQUAL');
-  t.equal(queryTree.data[2].type, 'EQUAL');
+  t.equal(queryTree.data[0].type, 'EQUAL')
+  t.equal(queryTree.data[1].type, 'EQUAL')
+  t.equal(queryTree.data[2].type, 'EQUAL')
 
-  t.end();
-});
+  t.end()
+})
 
 prepareAndRunTest(
   'operators paginate startFrom descending',
@@ -194,187 +183,181 @@ prepareAndRunTest(
     const queryTreePaginate = query(
       fromDB(db),
       and(slowEqual('value.content.type', 'post')),
-      paginate(10),
-    );
+      paginate(10)
+    )
 
     const queryTreeStartFrom = query(
       fromDB(db),
       and(slowEqual('value.content.type', 'post')),
-      startFrom(5),
-    );
+      startFrom(5)
+    )
 
     const queryTreeDescending = query(
       fromDB(db),
       and(slowEqual('value.content.type', 'post')),
-      descending(),
-    );
+      descending()
+    )
 
     const queryTreeAll = query(
       fromDB(db),
       and(slowEqual('value.content.type', 'post')),
       startFrom(5),
       paginate(10),
-      descending(),
-    );
+      descending()
+    )
 
-    t.equal(queryTreePaginate.meta.pageSize, 10);
-    t.equal(queryTreeStartFrom.meta.offset, 5);
-    t.equal(queryTreeDescending.meta.descending, true);
+    t.equal(queryTreePaginate.meta.pageSize, 10)
+    t.equal(queryTreeStartFrom.meta.offset, 5)
+    t.equal(queryTreeDescending.meta.descending, true)
 
-    t.equal(queryTreeAll.meta.pageSize, 10);
-    t.equal(queryTreeAll.meta.offset, 5);
-    t.equal(queryTreeAll.meta.descending, true);
+    t.equal(queryTreeAll.meta.pageSize, 10)
+    t.equal(queryTreeAll.meta.offset, 5)
+    t.equal(queryTreeAll.meta.descending, true)
 
-    t.end();
-  },
-);
+    t.end()
+  }
+)
 
 prepareAndRunTest('operator gt', dir, (t, db, raf) => {
   const queryTree = query(
     fromDB(db),
-    and(equal(helpers.seekAuthor, alice.id, 'author'), gt(2, 'sequence')),
-  );
+    and(equal(helpers.seekAuthor, alice.id, 'author'), gt(2, 'sequence'))
+  )
 
-  t.equal(typeof queryTree, 'object', 'queryTree is an object');
+  t.equal(typeof queryTree, 'object', 'queryTree is an object')
 
-  t.equal(queryTree.type, 'AND');
-  t.true(Array.isArray(queryTree.data), '.data is an array');
+  t.equal(queryTree.type, 'AND')
+  t.true(Array.isArray(queryTree.data), '.data is an array')
 
-  t.equal(queryTree.data[0].type, 'EQUAL');
-  t.equal(queryTree.data[0].data.indexType, 'author');
-  t.deepEqual(queryTree.data[0].data.value, Buffer.from(alice.id));
-  t.true(queryTree.data[0].data.seek.toString().includes('bipf.seekKey'));
+  t.equal(queryTree.data[0].type, 'EQUAL')
+  t.equal(queryTree.data[0].data.indexType, 'author')
+  t.deepEqual(queryTree.data[0].data.value, Buffer.from(alice.id))
+  t.true(queryTree.data[0].data.seek.toString().includes('bipf.seekKey'))
 
-  t.equal(queryTree.data[1].type, 'GT');
+  t.equal(queryTree.data[1].type, 'GT')
   t.equal(queryTree.data[1].data.indexName, 'sequence')
   t.equal(queryTree.data[1].data.value, 2)
 
-  t.end();
+  t.end()
 })
 
 prepareAndRunTest('operator gte', dir, (t, db, raf) => {
   const queryTree = query(
     fromDB(db),
-    and(equal(helpers.seekAuthor, alice.id, 'author'), gte(2, 'sequence')),
-  );
+    and(equal(helpers.seekAuthor, alice.id, 'author'), gte(2, 'sequence'))
+  )
 
-  t.equal(typeof queryTree, 'object', 'queryTree is an object');
+  t.equal(typeof queryTree, 'object', 'queryTree is an object')
 
-  t.equal(queryTree.type, 'AND');
-  t.true(Array.isArray(queryTree.data), '.data is an array');
+  t.equal(queryTree.type, 'AND')
+  t.true(Array.isArray(queryTree.data), '.data is an array')
 
-  t.equal(queryTree.data[0].type, 'EQUAL');
+  t.equal(queryTree.data[0].type, 'EQUAL')
 
-  t.equal(queryTree.data[1].type, 'GTE');
+  t.equal(queryTree.data[1].type, 'GTE')
   t.equal(queryTree.data[1].data.indexName, 'sequence')
   t.equal(queryTree.data[1].data.value, 2)
 
-  t.end();
+  t.end()
 })
 
 prepareAndRunTest('operator lt', dir, (t, db, raf) => {
   const queryTree = query(
     fromDB(db),
-    and(equal(helpers.seekAuthor, alice.id, 'author'), lt(2, 'sequence')),
-  );
+    and(equal(helpers.seekAuthor, alice.id, 'author'), lt(2, 'sequence'))
+  )
 
-  t.equal(typeof queryTree, 'object', 'queryTree is an object');
+  t.equal(typeof queryTree, 'object', 'queryTree is an object')
 
-  t.equal(queryTree.type, 'AND');
-  t.true(Array.isArray(queryTree.data), '.data is an array');
+  t.equal(queryTree.type, 'AND')
+  t.true(Array.isArray(queryTree.data), '.data is an array')
 
-  t.equal(queryTree.data[0].type, 'EQUAL');
+  t.equal(queryTree.data[0].type, 'EQUAL')
 
-  t.equal(queryTree.data[1].type, 'LT');
+  t.equal(queryTree.data[1].type, 'LT')
   t.equal(queryTree.data[1].data.indexName, 'sequence')
   t.equal(queryTree.data[1].data.value, 2)
 
-  t.end();
+  t.end()
 })
 
 prepareAndRunTest('operator lte', dir, (t, db, raf) => {
   const queryTree = query(
     fromDB(db),
-    and(equal(helpers.seekAuthor, alice.id, 'author'), lte(2, 'sequence')),
-  );
+    and(equal(helpers.seekAuthor, alice.id, 'author'), lte(2, 'sequence'))
+  )
 
-  t.equal(typeof queryTree, 'object', 'queryTree is an object');
+  t.equal(typeof queryTree, 'object', 'queryTree is an object')
 
-  t.equal(queryTree.type, 'AND');
-  t.true(Array.isArray(queryTree.data), '.data is an array');
+  t.equal(queryTree.type, 'AND')
+  t.true(Array.isArray(queryTree.data), '.data is an array')
 
-  t.equal(queryTree.data[0].type, 'EQUAL');
+  t.equal(queryTree.data[0].type, 'EQUAL')
 
-  t.equal(queryTree.data[1].type, 'LTE');
+  t.equal(queryTree.data[1].type, 'LTE')
   t.equal(queryTree.data[1].data.indexName, 'sequence')
   t.equal(queryTree.data[1].data.value, 2)
 
-  t.end();
+  t.end()
 })
 
 prepareAndRunTest('operator offsets', dir, (t, db, raf) => {
-  const queryTree = query(
-    fromDB(db),
-    and(offsets([10,20])),
-  );
+  const queryTree = query(fromDB(db), and(offsets([10, 20])))
 
-  t.equal(typeof queryTree, 'object', 'queryTree is an object');
+  t.equal(typeof queryTree, 'object', 'queryTree is an object')
 
-  t.equal(queryTree.type, 'OFFSETS');
-  t.true(Array.isArray(queryTree.offsets), '.offsets is an array');
+  t.equal(queryTree.type, 'OFFSETS')
+  t.true(Array.isArray(queryTree.offsets), '.offsets is an array')
 
-  t.equal(queryTree.offsets[0], 10);
-  t.equal(queryTree.offsets[1], 20);
+  t.equal(queryTree.offsets[0], 10)
+  t.equal(queryTree.offsets[1], 20)
 
-  t.end();
+  t.end()
 })
 
 prepareAndRunTest('operator seqs', dir, (t, db, raf) => {
-  const queryTree = query(
-    fromDB(db),
-    and(seqs([11,12])),
-  );
+  const queryTree = query(fromDB(db), and(seqs([11, 12])))
 
-  t.equal(typeof queryTree, 'object', 'queryTree is an object');
+  t.equal(typeof queryTree, 'object', 'queryTree is an object')
 
-  t.equal(queryTree.type, 'SEQS');
-  t.true(Array.isArray(queryTree.seqs), '.seqs is an array');
+  t.equal(queryTree.type, 'SEQS')
+  t.true(Array.isArray(queryTree.seqs), '.seqs is an array')
 
-  t.equal(queryTree.seqs[0], 11);
-  t.equal(queryTree.seqs[1], 12);
+  t.equal(queryTree.seqs[0], 11)
+  t.equal(queryTree.seqs[1], 12)
 
-  t.end();
+  t.end()
 })
 
 prepareAndRunTest('operators fromDB then toCallback', dir, (t, db, raf) => {
-  const msg = {type: 'post', text: 'Testing!'};
-  let state = validate.initial();
-  state = validate.appendNew(state, null, alice, msg, Date.now());
-  state = validate.appendNew(state, null, bob, msg, Date.now()+1);
+  const msg = { type: 'post', text: 'Testing!' }
+  let state = validate.initial()
+  state = validate.appendNew(state, null, alice, msg, Date.now())
+  state = validate.appendNew(state, null, bob, msg, Date.now() + 1)
 
   addMsg(state.queue[0].value, raf, (e1, msg1) => {
     addMsg(state.queue[1].value, raf, (e2, msg2) => {
       query(
         fromDB(db),
         toCallback((err, msgs) => {
-          t.error(err, 'toCallback got no error');
-          t.equal(msgs.length, 2, 'toCallback got two messages');
-          t.equal(msgs[0].value.author, alice.id);
-          t.equal(msgs[0].value.content.type, 'post');
-          t.equal(msgs[1].value.author, bob.id);
-          t.equal(msgs[1].value.content.type, 'post');
-          t.end();
-        }),
-      );
-    });
-  });
-});
+          t.error(err, 'toCallback got no error')
+          t.equal(msgs.length, 2, 'toCallback got two messages')
+          t.equal(msgs[0].value.author, alice.id)
+          t.equal(msgs[0].value.content.type, 'post')
+          t.equal(msgs[1].value.author, bob.id)
+          t.equal(msgs[1].value.content.type, 'post')
+          t.end()
+        })
+      )
+    })
+  })
+})
 
 prepareAndRunTest('operators toCallback', dir, (t, db, raf) => {
-  const msg = {type: 'post', text: 'Testing!'};
-  let state = validate.initial();
-  state = validate.appendNew(state, null, alice, msg, Date.now());
-  state = validate.appendNew(state, null, bob, msg, Date.now()+1);
+  const msg = { type: 'post', text: 'Testing!' }
+  let state = validate.initial()
+  state = validate.appendNew(state, null, alice, msg, Date.now())
+  state = validate.appendNew(state, null, bob, msg, Date.now() + 1)
 
   addMsg(state.queue[0].value, raf, (e1, msg1) => {
     addMsg(state.queue[1].value, raf, (e2, msg2) => {
@@ -385,24 +368,24 @@ prepareAndRunTest('operators toCallback', dir, (t, db, raf) => {
           slowEqual('value.author', bob.id)
         ),
         toCallback((err, msgs) => {
-          t.error(err, 'toCallback got no error');
-          t.equal(msgs.length, 2, 'toCallback got two messages');
-          t.equal(msgs[0].value.author, alice.id);
-          t.equal(msgs[0].value.content.type, 'post');
-          t.equal(msgs[1].value.author, bob.id);
-          t.equal(msgs[1].value.content.type, 'post');
-          t.end();
-        }),
-      );
-    });
-  });
-});
+          t.error(err, 'toCallback got no error')
+          t.equal(msgs.length, 2, 'toCallback got two messages')
+          t.equal(msgs[0].value.author, alice.id)
+          t.equal(msgs[0].value.content.type, 'post')
+          t.equal(msgs[1].value.author, bob.id)
+          t.equal(msgs[1].value.content.type, 'post')
+          t.end()
+        })
+      )
+    })
+  })
+})
 
 prepareAndRunTest('operators toPromise', dir, (t, db, raf) => {
-  const msg = {type: 'post', text: 'Testing!'};
-  let state = validate.initial();
-  state = validate.appendNew(state, null, alice, msg, Date.now());
-  state = validate.appendNew(state, null, bob, msg, Date.now()+1);
+  const msg = { type: 'post', text: 'Testing!' }
+  let state = validate.initial()
+  state = validate.appendNew(state, null, alice, msg, Date.now())
+  state = validate.appendNew(state, null, bob, msg, Date.now() + 1)
 
   addMsg(state.queue[0].value, raf, (e1, msg1) => {
     addMsg(state.queue[1].value, raf, (e2, msg2) => {
@@ -412,29 +395,29 @@ prepareAndRunTest('operators toPromise', dir, (t, db, raf) => {
           slowEqual('value.author', alice.id),
           slowEqual('value.author', bob.id)
         ),
-        toPromise(),
+        toPromise()
       ).then(
         (msgs) => {
-          t.equal(msgs.length, 2, 'toPromise got two messages');
-          t.equal(msgs[0].value.author, alice.id);
-          t.equal(msgs[0].value.content.type, 'post');
-          t.equal(msgs[1].value.author, bob.id);
-          t.equal(msgs[1].value.content.type, 'post');
-          t.end();
+          t.equal(msgs.length, 2, 'toPromise got two messages')
+          t.equal(msgs[0].value.author, alice.id)
+          t.equal(msgs[0].value.content.type, 'post')
+          t.equal(msgs[1].value.author, bob.id)
+          t.equal(msgs[1].value.content.type, 'post')
+          t.end()
         },
         (err) => {
-          t.fail(err);
-        },
-      );
-    });
-  });
-});
+          t.fail(err)
+        }
+      )
+    })
+  })
+})
 
 prepareAndRunTest('operators toPullStream', dir, (t, db, raf) => {
-  const msg = {type: 'post', text: 'Testing!'};
-  let state = validate.initial();
-  state = validate.appendNew(state, null, alice, msg, Date.now());
-  state = validate.appendNew(state, null, bob, msg, Date.now()+1);
+  const msg = { type: 'post', text: 'Testing!' }
+  let state = validate.initial()
+  state = validate.appendNew(state, null, alice, msg, Date.now())
+  state = validate.appendNew(state, null, bob, msg, Date.now() + 1)
 
   addMsg(state.queue[0].value, raf, (e1, msg1) => {
     addMsg(state.queue[1].value, raf, (e2, msg2) => {
@@ -446,29 +429,29 @@ prepareAndRunTest('operators toPullStream', dir, (t, db, raf) => {
             slowEqual('value.author', bob.id)
           ),
           paginate(2),
-          toPullStream(),
+          toPullStream()
         ),
         pull.collect((err, pages) => {
-          t.error(err, 'toPullStream got no error');
-          t.equal(pages.length, 1, 'toPullStream got one page');
+          t.error(err, 'toPullStream got no error')
+          t.equal(pages.length, 1, 'toPullStream got one page')
           const msgs = pages[0]
-          t.equal(msgs.length, 2, 'page has two messages');
-          t.equal(msgs[0].value.author, alice.id);
-          t.equal(msgs[0].value.content.type, 'post');
-          t.equal(msgs[1].value.author, bob.id);
-          t.equal(msgs[1].value.content.type, 'post');
-          t.end();
-        }),
-      );
-    });
-  });
-});
+          t.equal(msgs.length, 2, 'page has two messages')
+          t.equal(msgs[0].value.author, alice.id)
+          t.equal(msgs[0].value.content.type, 'post')
+          t.equal(msgs[1].value.author, bob.id)
+          t.equal(msgs[1].value.content.type, 'post')
+          t.end()
+        })
+      )
+    })
+  })
+})
 
 prepareAndRunTest('operators toAsyncIter', dir, (t, db, raf) => {
-  const msg = {type: 'post', text: 'Testing!'};
-  let state = validate.initial();
-  state = validate.appendNew(state, null, alice, msg, Date.now());
-  state = validate.appendNew(state, null, bob, msg, Date.now()+1);
+  const msg = { type: 'post', text: 'Testing!' }
+  let state = validate.initial()
+  state = validate.appendNew(state, null, alice, msg, Date.now())
+  state = validate.appendNew(state, null, bob, msg, Date.now() + 1)
 
   addMsg(state.queue[0].value, raf, (e1, msg1) => {
     addMsg(state.queue[1].value, raf, async (e2, msg2) => {
@@ -481,31 +464,31 @@ prepareAndRunTest('operators toAsyncIter', dir, (t, db, raf) => {
             slowEqual('value.author', bob.id)
           ),
           paginate(2),
-          toAsyncIter(),
+          toAsyncIter()
         )
         for await (let page of results) {
           t.equal(i, 0, 'just one page')
-          i += 1;
+          i += 1
           const msgs = page
-          t.equal(msgs.length, 2, 'page has two messages');
-          t.equal(msgs[0].value.author, alice.id);
-          t.equal(msgs[0].value.content.type, 'post');
-          t.equal(msgs[1].value.author, bob.id);
-          t.equal(msgs[1].value.content.type, 'post');
-          t.end();
+          t.equal(msgs.length, 2, 'page has two messages')
+          t.equal(msgs[0].value.author, alice.id)
+          t.equal(msgs[0].value.content.type, 'post')
+          t.equal(msgs[1].value.author, bob.id)
+          t.equal(msgs[1].value.content.type, 'post')
+          t.end()
         }
       } catch (err) {
         t.fail(err)
       }
-    });
-  });
-});
+    })
+  })
+})
 
 prepareAndRunTest('operators toCallback with startFrom', dir, (t, db, raf) => {
-  const msg = {type: 'post', text: 'Testing!'};
-  let state = validate.initial();
-  state = validate.appendNew(state, null, alice, msg, Date.now());
-  state = validate.appendNew(state, null, bob, msg, Date.now()+1);
+  const msg = { type: 'post', text: 'Testing!' }
+  let state = validate.initial()
+  state = validate.appendNew(state, null, alice, msg, Date.now())
+  state = validate.appendNew(state, null, bob, msg, Date.now() + 1)
 
   addMsg(state.queue[0].value, raf, (e1, msg1) => {
     addMsg(state.queue[1].value, raf, (e2, msg2) => {
@@ -517,22 +500,22 @@ prepareAndRunTest('operators toCallback with startFrom', dir, (t, db, raf) => {
         ),
         startFrom(1),
         toCallback((err, msgs) => {
-          t.error(err, 'toCallback got no error');
-          t.equal(msgs.length, 1, 'toCallback got one messages');
-          t.equal(msgs[0].value.author, bob.id);
-          t.equal(msgs[0].value.content.type, 'post');
-          t.end();
-        }),
-      );
-    });
-  });
-});
+          t.error(err, 'toCallback got no error')
+          t.equal(msgs.length, 1, 'toCallback got one messages')
+          t.equal(msgs[0].value.author, bob.id)
+          t.equal(msgs[0].value.content.type, 'post')
+          t.end()
+        })
+      )
+    })
+  })
+})
 
 prepareAndRunTest('operators toCallback with descending', dir, (t, db, raf) => {
-  const msg = {type: 'post', text: 'Testing!'};
-  let state = validate.initial();
-  state = validate.appendNew(state, null, alice, msg, Date.now());
-  state = validate.appendNew(state, null, bob, msg, Date.now()+1);
+  const msg = { type: 'post', text: 'Testing!' }
+  let state = validate.initial()
+  state = validate.appendNew(state, null, alice, msg, Date.now())
+  state = validate.appendNew(state, null, bob, msg, Date.now() + 1)
 
   addMsg(state.queue[0].value, raf, (e1, msg1) => {
     addMsg(state.queue[1].value, raf, (e2, msg2) => {
@@ -544,42 +527,44 @@ prepareAndRunTest('operators toCallback with descending', dir, (t, db, raf) => {
         ),
         descending(),
         toCallback((err, msgs) => {
-          t.error(err, 'toCallback got no error');
-          t.equal(msgs.length, 2, 'toCallback got two messages');
-          t.equal(msgs[0].value.author, bob.id);
-          t.equal(msgs[0].value.content.type, 'post');
-          t.equal(msgs[1].value.author, alice.id);
-          t.equal(msgs[1].value.content.type, 'post');
-          t.end();
-        }),
-      );
-    });
-  });
-});
+          t.error(err, 'toCallback got no error')
+          t.equal(msgs.length, 2, 'toCallback got two messages')
+          t.equal(msgs[0].value.author, bob.id)
+          t.equal(msgs[0].value.content.type, 'post')
+          t.equal(msgs[1].value.author, alice.id)
+          t.equal(msgs[1].value.content.type, 'post')
+          t.end()
+        })
+      )
+    })
+  })
+})
 
 prepareAndRunTest('support deferred operations', dir, (t, db, raf) => {
-  const msg = {type: 'post', text: 'Testing!'};
-  let state = validate.initial();
-  state = validate.appendNew(state, null, alice, msg, Date.now());
-  state = validate.appendNew(state, null, bob, msg, Date.now()+1);
+  const msg = { type: 'post', text: 'Testing!' }
+  let state = validate.initial()
+  state = validate.appendNew(state, null, alice, msg, Date.now())
+  state = validate.appendNew(state, null, bob, msg, Date.now() + 1)
 
   addMsg(state.queue[0].value, raf, (e1, msg1) => {
     addMsg(state.queue[1].value, raf, (e2, msg2) => {
       query(
         fromDB(db),
-        and(deferred((meta, cb) => {
-          setTimeout(() => {
-            cb(null, slowEqual('value.author', alice.id))
-          }, 100)
-        })),
+        and(
+          deferred((meta, cb) => {
+            setTimeout(() => {
+              cb(null, slowEqual('value.author', alice.id))
+            }, 100)
+          })
+        ),
         toCallback((err, msgs) => {
-          t.error(err, 'toCallback got no error');
-          t.equal(msgs.length, 1, 'toCallback got two messages');
-          t.equal(msgs[0].value.author, alice.id);
-          t.equal(msgs[0].value.content.type, 'post');
-          t.end();
-        }),
-      );
-    });
-  });
-});
+          t.error(err, 'toCallback got no error')
+          t.equal(msgs.length, 1, 'toCallback got two messages')
+          t.equal(msgs[0].value.author, alice.id)
+          t.equal(msgs[0].value.content.type, 'post')
+          t.end()
+        })
+      )
+    })
+  })
+})

--- a/test/query-seq.js
+++ b/test/query-seq.js
@@ -24,8 +24,8 @@ prepareAndRunTest('Basic', dir, (t, db, raf) => {
     data: {
       seek: helpers.seekType,
       value: 'post',
-      indexType: "type"
-    }
+      indexType: 'type',
+    },
   }
 
   addMsg(state.queue[0].value, raf, (err, msg1) => {

--- a/test/query.js
+++ b/test/query.js
@@ -27,8 +27,8 @@ prepareAndRunTest('Multiple types', dir, (t, db, raf) => {
     data: {
       seek: helpers.seekType,
       value: 'post',
-      indexType: "type"
-    }
+      indexType: 'type',
+    },
   }
 
   const contactQuery = {
@@ -36,8 +36,8 @@ prepareAndRunTest('Multiple types', dir, (t, db, raf) => {
     data: {
       seek: helpers.seekType,
       value: 'contact',
-      indexType: "type"
-    }
+      indexType: 'type',
+    },
   }
 
   addMsg(state.queue[0].value, raf, (err, msg) => {
@@ -67,16 +67,16 @@ prepareAndRunTest('Top 1 multiple types', dir, (t, db, raf) => {
 
   let state = validate.initial()
   state = validate.appendNew(state, null, keys, msg1, Date.now())
-  state = validate.appendNew(state, null, keys, msg2, Date.now()+1)
-  state = validate.appendNew(state, null, keys, msg3, Date.now()+2)
+  state = validate.appendNew(state, null, keys, msg2, Date.now() + 1)
+  state = validate.appendNew(state, null, keys, msg3, Date.now() + 2)
 
   const typeQuery = {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
       value: 'post',
-      indexType: "type"
-    }
+      indexType: 'type',
+    },
   }
 
   addMsg(state.queue[0].value, raf, (err, msg) => {
@@ -99,16 +99,16 @@ prepareAndRunTest('Offset', dir, (t, db, raf) => {
 
   let state = validate.initial()
   state = validate.appendNew(state, null, keys, msg1, Date.now())
-  state = validate.appendNew(state, null, keys, msg2, Date.now()+1)
-  state = validate.appendNew(state, null, keys, msg3, Date.now()+2)
+  state = validate.appendNew(state, null, keys, msg2, Date.now() + 1)
+  state = validate.appendNew(state, null, keys, msg3, Date.now() + 2)
 
   const typeQuery = {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
       value: 'post',
-      indexType: "type"
-    }
+      indexType: 'type',
+    },
   }
 
   addMsg(state.queue[0].value, raf, (err, msg) => {
@@ -135,8 +135,8 @@ prepareAndRunTest('Buffer', dir, (t, db, raf) => {
     data: {
       seek: helpers.seekType,
       value: Buffer.from('post'),
-      indexType: "type"
-    }
+      indexType: 'type',
+    },
   }
 
   addMsg(state.queue[0].value, raf, (err, msg) => {
@@ -161,8 +161,8 @@ prepareAndRunTest('Undefined', dir, (t, db, raf) => {
     data: {
       seek: helpers.seekRoot,
       value: undefined,
-      indexType: "root"
-    }
+      indexType: 'root',
+    },
   }
 
   addMsg(state.queue[0].value, raf, (err, msg) => {
@@ -184,28 +184,30 @@ prepareAndRunTest('GT,GTE,LT,LTE', dir, (t, db, raf) => {
 
   let state = validate.initial()
   state = validate.appendNew(state, null, keys, msg1, Date.now())
-  state = validate.appendNew(state, null, keys, msg2, Date.now()+1)
-  state = validate.appendNew(state, null, keys, msg3, Date.now()+2)
-  state = validate.appendNew(state, null, keys, msg4, Date.now()+3)
+  state = validate.appendNew(state, null, keys, msg2, Date.now() + 1)
+  state = validate.appendNew(state, null, keys, msg3, Date.now() + 2)
+  state = validate.appendNew(state, null, keys, msg4, Date.now() + 3)
 
   const filterQuery = {
     type: 'AND',
     data: [
-      { type: 'GT',
+      {
+        type: 'GT',
         data: {
           indexName: 'sequence',
           value: 1,
-        }
+        },
       },
-      { type: 'EQUAL',
+      {
+        type: 'EQUAL',
         data: {
           seek: helpers.seekAuthor,
           value: keys.id,
-          indexType: "author",
-          indexAll: true
-        }
-      }
-    ]
+          indexType: 'author',
+          indexAll: true,
+        },
+      },
+    ],
   }
 
   addMsg(state.queue[0].value, raf, (err, dbMsg1) => {
@@ -259,16 +261,16 @@ prepareAndRunTest('GTE Zero', dir, (t, db, raf) => {
 
   let state = validate.initial()
   state = validate.appendNew(state, null, keys, msg1, Date.now())
-  state = validate.appendNew(state, null, keys, msg2, Date.now()+1)
-  state = validate.appendNew(state, null, keys, msg3, Date.now()+2)
-  state = validate.appendNew(state, null, keys, msg4, Date.now()+3)
+  state = validate.appendNew(state, null, keys, msg2, Date.now() + 1)
+  state = validate.appendNew(state, null, keys, msg3, Date.now() + 2)
+  state = validate.appendNew(state, null, keys, msg4, Date.now() + 3)
 
   const filterQuery = {
     type: 'GTE',
     data: {
       indexName: 'sequence',
       value: 0,
-    }
+    },
   }
 
   addMsg(state.queue[0].value, raf, (err, dbMsg1) => {
@@ -302,18 +304,19 @@ prepareAndRunTest('Data seqs', dir, (t, db, raf) => {
   const dataQuery = {
     type: 'AND',
     data: [
-      { type: 'EQUAL',
+      {
+        type: 'EQUAL',
         data: {
           seek: helpers.seekType,
           value: 'post',
-          indexType: "type"
-        }
+          indexType: 'type',
+        },
       },
       {
         type: 'SEQS',
-        seqs: [363, 765]
-      }
-    ]
+        seqs: [363, 765],
+      },
+    ],
   }
 
   addMsg(state.queue[0].value, raf, (err, msg) => {
@@ -341,7 +344,7 @@ prepareAndRunTest('Data offsets simple', dir, (t, db, raf) => {
 
   const dataQuery = {
     type: 'OFFSETS',
-    offsets: [1, 2]
+    offsets: [1, 2],
   }
 
   addMsg(state.queue[0].value, raf, (err, msg) => {
@@ -371,18 +374,19 @@ prepareAndRunTest('Data offsets', dir, (t, db, raf) => {
   const dataQuery = {
     type: 'AND',
     data: [
-      { type: 'EQUAL',
+      {
+        type: 'EQUAL',
         data: {
           seek: helpers.seekType,
           value: 'post',
-          indexType: "type"
-        }
+          indexType: 'type',
+        },
       },
       {
         type: 'OFFSETS',
-        offsets: [1, 2]
-      }
-    ]
+        offsets: [1, 2],
+      },
+    ],
   }
 
   addMsg(state.queue[0].value, raf, (err, msg) => {
@@ -413,8 +417,8 @@ prepareAndRunTest('Multiple ands', dir, (t, db, raf) => {
     data: {
       seek: helpers.seekType,
       value: 'post',
-      indexType: "type"
-    }
+      indexType: 'type',
+    },
   }
 
   const authorQuery = {
@@ -422,8 +426,8 @@ prepareAndRunTest('Multiple ands', dir, (t, db, raf) => {
     data: {
       seek: helpers.seekAuthor,
       value: keys.id,
-      indexType: "author"
-    }
+      indexType: 'author',
+    },
   }
 
   const seqQuery = {
@@ -431,12 +435,12 @@ prepareAndRunTest('Multiple ands', dir, (t, db, raf) => {
     data: {
       indexName: 'sequence',
       value: 1,
-    }
+    },
   }
 
   const allQuery = {
     type: 'AND',
-    data: [typeQuery, authorQuery, seqQuery]
+    data: [typeQuery, authorQuery, seqQuery],
   }
 
   addMsg(state.queue[0].value, raf, (err, msg) => {
@@ -467,26 +471,26 @@ prepareAndRunTest('Multiple ors', dir, (t, db, raf) => {
     data: {
       seek: helpers.seekType,
       value: 'post',
-      indexType: "type"
-    }
+      indexType: 'type',
+    },
   }
 
   const authorRandomQuery = {
     type: 'EQUAL',
     data: {
       seek: helpers.seekAuthor,
-      value: "random",
-      indexType: "author"
-    }
+      value: 'random',
+      indexType: 'author',
+    },
   }
 
   const authorRandom2Query = {
     type: 'EQUAL',
     data: {
       seek: helpers.seekAuthor,
-      value: "random2",
-      indexType: "author"
-    }
+      value: 'random2',
+      indexType: 'author',
+    },
   }
 
   const authorQuery = {
@@ -494,18 +498,18 @@ prepareAndRunTest('Multiple ors', dir, (t, db, raf) => {
     data: {
       seek: helpers.seekAuthor,
       value: keys.id,
-      indexType: "author"
-    }
+      indexType: 'author',
+    },
   }
 
   const authorsQuery = {
     type: 'OR',
-    data: [authorRandomQuery, authorRandom2Query, authorQuery]
+    data: [authorRandomQuery, authorRandom2Query, authorQuery],
   }
 
   const allQuery = {
     type: 'AND',
-    data: [typeQuery, authorsQuery]
+    data: [typeQuery, authorsQuery],
   }
 
   addMsg(state.queue[0].value, raf, (err, msg) => {

--- a/test/save-load.js
+++ b/test/save-load.js
@@ -11,11 +11,10 @@ mkdirp.sync(dir)
 
 prepareAndRunTest('SaveLoad', dir, (t, db, raf) => {
   var data = new TypedFastBitSet()
-  for (var i = 0; i < 10; i += 2)
-    data.add(i)
+  for (var i = 0; i < 10; i += 2) data.add(i)
 
-  db.saveIndex("test", 123, data, (err) => {
-    const file = path.join(dir, "indexesSaveLoad", "test.index")
+  db.saveIndex('test', 123, data, (err) => {
+    const file = path.join(dir, 'indexesSaveLoad', 'test.index')
     db.loadIndex(file, Uint32Array, (err, index) => {
       let loadedData = new TypedFastBitSet()
       loadedData.words = index.data
@@ -24,7 +23,7 @@ prepareAndRunTest('SaveLoad', dir, (t, db, raf) => {
 
       loadedData.add(10)
 
-      db.saveIndex("test", 1234, loadedData, (err) => {
+      db.saveIndex('test', 1234, loadedData, (err) => {
         db.loadIndex(file, Uint32Array, (err, index) => {
           let loadedData2 = new TypedFastBitSet()
           loadedData2.words = index.data
@@ -39,18 +38,16 @@ prepareAndRunTest('SaveLoad', dir, (t, db, raf) => {
 
 prepareAndRunTest('SaveLoadOffset', dir, (t, db, raf) => {
   var data = new Uint32Array(16 * 1000)
-  for (var i = 0; i < 10; i += 1)
-    data[i] = i
+  for (var i = 0; i < 10; i += 1) data[i] = i
 
-  db.saveTypedArray("test", 123, 10, data, (err) => {
-    const file = path.join(dir, "indexesSaveLoadOffset", "test.index")
+  db.saveTypedArray('test', 123, 10, data, (err) => {
+    const file = path.join(dir, 'indexesSaveLoadOffset', 'test.index')
     db.loadIndex(file, Uint32Array, (err, loadedData) => {
-      for (var i = 0; i < 10; i += 1)
-        t.equal(data[i], loadedData.data[i])
+      for (var i = 0; i < 10; i += 1) t.equal(data[i], loadedData.data[i])
 
       loadedData.data[10] = 10
 
-      db.saveTypedArray("test", 1234, 11, loadedData.data, (err) => {
+      db.saveTypedArray('test', 1234, 11, loadedData.data, (err) => {
         db.loadIndex(file, Uint32Array, (err, loadedData2) => {
           for (var i = 0; i < 11; i += 1)
             t.equal(loadedData.data[i], loadedData2.data[i])
@@ -63,18 +60,16 @@ prepareAndRunTest('SaveLoadOffset', dir, (t, db, raf) => {
 
 prepareAndRunTest('SaveLoadTimestamp', dir, (t, db, raf) => {
   var data = new Float64Array(16 * 1000)
-  for (var i = 0; i < 10; i += 1)
-    data[i] = i * 1000000
+  for (var i = 0; i < 10; i += 1) data[i] = i * 1000000
 
-  db.saveTypedArray("test", 123, 10, data, (err) => {
-    const file = path.join(dir, "indexesSaveLoadTimestamp", "test.index")
+  db.saveTypedArray('test', 123, 10, data, (err) => {
+    const file = path.join(dir, 'indexesSaveLoadTimestamp', 'test.index')
     db.loadIndex(file, Float64Array, (err, loadedData) => {
-      for (var i = 0; i < 10; i += 1)
-        t.equal(data[i], loadedData.data[i])
+      for (var i = 0; i < 10; i += 1) t.equal(data[i], loadedData.data[i])
 
       loadedData.data[10] = 10 * 1000000
 
-      db.saveTypedArray("test", 1234, 11, loadedData.data, (err) => {
+      db.saveTypedArray('test', 1234, 11, loadedData.data, (err) => {
         db.loadIndex(file, Float64Array, (err, loadedData2) => {
           for (var i = 0; i < 11; i += 1)
             t.equal(loadedData.data[i], loadedData2.data[i])


### PR DESCRIPTION
- Commit https://github.com/ssb-ngi-pointer/jitdb/commit/2e03a7a6ca5769b41adbba48a636c97b9c1f3a7b
  - Configures Prettier
  - `npm run format-code` formats everything
  - `npm run format-code-staged` formats what is git staged, this runs in a pre-commit hook
- Commit https://github.com/ssb-ngi-pointer/jitdb/commit/381852242e645bfc760977fd8951295dc6b6e657
  - This is just the application of `npm run format-code`, nothing else

Note that `.prettierrc` allows configuring (a bit) the codestyle, e.g. semi-colons or not, spaces between things, etc.