### PR TITLE
replace dep pify with promisify-4loc

### DIFF
--- a/operators.js
+++ b/operators.js
@@ -1,6 +1,6 @@
 const bipf = require('bipf')
 const traverse = require('traverse')
-const promisify = require('pify')
+const promisify = require('promisify-4loc')
 
 function query(...cbs) {
   let res = cbs[0]

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "jsesc": "^3.0.2",
     "lodash.debounce": "^4.0.8",
     "mkdirp": "^1.0.4",
-    "pify": "^5.0.0",
+    "promisify-4loc": "1.0.0",
     "push-stream": "^11.0.0",
     "sanitize-filename": "^1.6.3",
     "traverse": "^0.6.6",


### PR DESCRIPTION
I found `pify` too big. I was gonna use it in db2 as well. so instead i took a quick detour and made https://github.com/staltz/promisify-4loc (mostly copied from https://github.com/staltz/promisify-tuple)