### PR TITLE
support deferred operator to return falsy values

### DIFF
--- a/operators.js
+++ b/operators.js
@@ -227,7 +227,7 @@ async function executeDeferredOps(ops, meta) {
   // Execute all deferred tasks and collect the results (and the paths)
   const allResults = await Promise.all(
     allDeferred.map(([path, obj]) =>
-      promisify(obj.task)(meta).then((result) => [path, result])
+      promisify(obj.task)(meta).then((result) => [path, result || {}])
     )
   )
 

--- a/test/operators.js
+++ b/test/operators.js
@@ -568,3 +568,34 @@ prepareAndRunTest('support deferred operations', dir, (t, db, raf) => {
     })
   })
 })
+
+prepareAndRunTest('support empty deferred operations', dir, (t, db, raf) => {
+  const msg = { type: 'post', text: 'Testing!' }
+  let state = validate.initial()
+  state = validate.appendNew(state, null, alice, msg, Date.now())
+  state = validate.appendNew(state, null, bob, msg, Date.now() + 1)
+
+  addMsg(state.queue[0].value, raf, (e1, msg1) => {
+    addMsg(state.queue[1].value, raf, (e2, msg2) => {
+      query(
+        fromDB(db),
+        and(
+          deferred((meta, cb) => {
+            setTimeout(() => {
+              cb(null, null)
+            }, 100)
+          })
+        ),
+        toCallback((err, msgs) => {
+          t.error(err, 'toCallback got no error')
+          t.equal(msgs.length, 2, 'toCallback got two messages')
+          t.equal(msgs[0].value.author, alice.id)
+          t.equal(msgs[0].value.content.type, 'post')
+          t.equal(msgs[1].value.author, bob.id)
+          t.equal(msgs[1].value.content.type, 'post')
+          t.end()
+        })
+      )
+    })
+  })
+})


### PR DESCRIPTION
This is in preparation of putting `onDrain` implicitly inside `query` in db2.

If `deferred`'s callback gives a falsy value, we make an empty object instead. This is mostly to support use cases that "wait for something" before executing the query.

```js
query(
  fromDB(jitdb),
  deferred(waitForThisStuffToHappenFirst),
  and(type('post'), author(me),
  toCallback(done)
)
```