### PR TITLE
refactor: extract files.js from index.js

### DIFF
--- a/files.js
+++ b/files.js
@@ -1,0 +1,98 @@
+const jsesc = require('jsesc')
+const sanitize = require('sanitize-filename')
+const TypedFastBitSet = require('typedfastbitset')
+const AtomicFile = require('atomic-file/buffer')
+const toBuffer = require('typedarray-to-buffer')
+
+function saveTypedArrayFile(filename, seq, count, tarr, cb) {
+  if (!cb) cb = () => {}
+
+  const dataBuffer = toBuffer(tarr)
+  const b = Buffer.alloc(8 + dataBuffer.length)
+  b.writeInt32LE(seq, 0)
+  b.writeInt32LE(count, 4)
+  dataBuffer.copy(b, 8)
+
+  const f = AtomicFile(filename)
+  f.set(b, cb)
+}
+
+function loadTypedArrayFile(filename, Type, cb) {
+  const f = AtomicFile(filename)
+  f.get((err, buf) => {
+    if (err) return cb(err)
+
+    const seq = buf.readInt32LE(0)
+    const count = buf.readInt32LE(4)
+    const body = buf.slice(8)
+
+    cb(null, {
+      seq,
+      count,
+      tarr: new Type(
+        body.buffer,
+        body.offset,
+        body.byteLength / (Type === Float64Array ? 8 : 4)
+      ),
+    })
+  })
+}
+
+function saveBitsetFile(filename, seq, bitset, cb) {
+  bitset.trim()
+  saveTypedArrayFile(filename, seq, bitset.count, bitset.words, cb)
+}
+
+function loadBitsetFile(filename, cb) {
+  loadTypedArrayFile(filename, Uint32Array, (err, { tarr, count, seq }) => {
+    if (err) cb(err)
+    else {
+      const bitset = new TypedFastBitSet()
+      bitset.words = tarr
+      bitset.count = count
+      cb(null, { seq, bitset })
+    }
+  })
+}
+
+function listFilesIDB(dir, cb) {
+  const IdbKvStore = require('idb-kv-store')
+  const store = new IdbKvStore(dir, { disableBroadcast: true })
+  store.keys(cb)
+}
+
+function listFilesFS(dir, cb) {
+  const fs = require('fs')
+  const mkdirp = require('mkdirp')
+  mkdirp(dir).then(() => {
+    fs.readdir(dir, cb)
+  }, cb)
+}
+
+function safeFilename(filename) {
+  // in general we want to escape wierd characters
+  let result = jsesc(filename)
+  // sanitize will remove special characters, which means that two
+  // indexes might end up with the same name so lets replace those
+  // with jsesc escapeEverything values
+  result = result.replace(/\./g, 'x2E')
+  result = result.replace(/\//g, 'x2F')
+  result = result.replace(/\?/g, 'x3F')
+  result = result.replace(/\</g, 'x3C')
+  result = result.replace(/\>/g, 'x3E')
+  result = result.replace(/\:/g, 'x3A')
+  result = result.replace(/\*/g, 'x2A')
+  result = result.replace(/\|/g, 'x7C')
+  // finally sanitize
+  return sanitize(result)
+}
+
+module.exports = {
+  saveTypedArrayFile,
+  loadTypedArrayFile,
+  saveBitsetFile,
+  loadBitsetFile,
+  listFilesIDB,
+  listFilesFS,
+  safeFilename,
+}

--- a/test/save-load.js
+++ b/test/save-load.js
@@ -1,33 +1,38 @@
 const test = require('tape')
 const path = require('path')
 const TypedFastBitSet = require('typedfastbitset')
-const { prepareAndRunTest, addMsg } = require('./common')()
 const rimraf = require('rimraf')
 const mkdirp = require('mkdirp')
+const {
+  saveTypedArrayFile,
+  loadTypedArrayFile,
+  saveBitsetFile,
+  loadBitsetFile,
+} = require('../files')
 
 const dir = '/tmp/jitdb-save-load'
 rimraf.sync(dir)
 mkdirp.sync(dir)
 
-prepareAndRunTest('SaveLoad', dir, (t, db, raf) => {
+test('save and load bitsets', (t) => {
+  const idxDir = path.join(dir, 'test-bitsets')
+  mkdirp.sync(idxDir)
+  const filename = path.join(idxDir, 'test.index')
+
   var bitset = new TypedFastBitSet()
   for (var i = 0; i < 10; i += 2) bitset.add(i)
 
-  db.saveIndex('test', 123, bitset, (err) => {
-    const file = path.join(dir, 'indexesSaveLoad', 'test.index')
-    db.loadIndex(file, Uint32Array, (err, index) => {
-      let loadedBitset = new TypedFastBitSet()
-      loadedBitset.words = index.tarr
-      loadedBitset.count = index.count
+  saveBitsetFile(filename, 123, bitset, (err) => {
+    loadBitsetFile(filename, (err, index) => {
+      t.error(err, 'no error')
+      let loadedBitset = index.bitset
       t.deepEqual(bitset.array(), loadedBitset.array())
-
       loadedBitset.add(10)
 
-      db.saveIndex('test', 1234, loadedBitset, (err) => {
-        db.loadIndex(file, Uint32Array, (err, index) => {
-          let loadedBitset2 = new TypedFastBitSet()
-          loadedBitset2.words = index.tarr
-          loadedBitset2.count = index.count
+      saveBitsetFile(filename, 1234, loadedBitset, (err) => {
+        loadBitsetFile(filename, (err, index) => {
+          t.error(err, 'no error')
+          let loadedBitset2 = index.bitset
           t.deepEqual(loadedBitset.array(), loadedBitset2.array())
           t.end()
         })
@@ -36,19 +41,22 @@ prepareAndRunTest('SaveLoad', dir, (t, db, raf) => {
   })
 })
 
-prepareAndRunTest('SaveLoadOffset', dir, (t, db, raf) => {
+test('save and load TypedArray for offset', (t) => {
+  const idxDir = path.join(dir, 'indexesSaveLoadOffset')
+  mkdirp.sync(idxDir)
+  const filename = path.join(idxDir, 'test.index')
+
   var tarr = new Uint32Array(16 * 1000)
   for (var i = 0; i < 10; i += 1) tarr[i] = i
 
-  db.saveTypedArray('test', 123, 10, tarr, (err) => {
-    const file = path.join(dir, 'indexesSaveLoadOffset', 'test.index')
-    db.loadIndex(file, Uint32Array, (err, loadedIdx) => {
+  saveTypedArrayFile(filename, 123, 10, tarr, (err) => {
+    loadTypedArrayFile(filename, Uint32Array, (err, loadedIdx) => {
       for (var i = 0; i < 10; i += 1) t.equal(tarr[i], loadedIdx.tarr[i])
 
       loadedIdx.tarr[10] = 10
 
-      db.saveTypedArray('test', 1234, 11, loadedIdx.tarr, (err) => {
-        db.loadIndex(file, Uint32Array, (err, loadedIdx2) => {
+      saveTypedArrayFile(filename, 1234, 11, loadedIdx.tarr, (err) => {
+        loadTypedArrayFile(filename, Uint32Array, (err, loadedIdx2) => {
           for (var i = 0; i < 11; i += 1)
             t.equal(loadedIdx.tarr[i], loadedIdx2.tarr[i])
           t.end()
@@ -58,19 +66,22 @@ prepareAndRunTest('SaveLoadOffset', dir, (t, db, raf) => {
   })
 })
 
-prepareAndRunTest('SaveLoadTimestamp', dir, (t, db, raf) => {
+test('save and load TypedArray for timestamp', (t) => {
+  const idxDir = path.join(dir, 'indexesSaveLoadTimestamp')
+  mkdirp.sync(idxDir)
+  const filename = path.join(idxDir, 'test.index')
+
   var tarr = new Float64Array(16 * 1000)
   for (var i = 0; i < 10; i += 1) tarr[i] = i * 1000000
 
-  db.saveTypedArray('test', 123, 10, tarr, (err) => {
-    const file = path.join(dir, 'indexesSaveLoadTimestamp', 'test.index')
-    db.loadIndex(file, Float64Array, (err, loadedIdx) => {
+  saveTypedArrayFile(filename, 123, 10, tarr, (err) => {
+    loadTypedArrayFile(filename, Float64Array, (err, loadedIdx) => {
       for (var i = 0; i < 10; i += 1) t.equal(tarr[i], loadedIdx.tarr[i])
 
       loadedIdx.tarr[10] = 10 * 1000000
 
-      db.saveTypedArray('test', 1234, 11, loadedIdx.tarr, (err) => {
-        db.loadIndex(file, Float64Array, (err, loadedIdx2) => {
+      saveTypedArrayFile(filename, 1234, 11, loadedIdx.tarr, (err) => {
+        loadTypedArrayFile(filename, Float64Array, (err, loadedIdx2) => {
           for (var i = 0; i < 11; i += 1)
             t.equal(loadedIdx.tarr[i], loadedIdx2.tarr[i])
           t.end()


### PR DESCRIPTION
This one is a lot of shuffling. I wanted to move persistence logic to its own file, so now `atomic-file` logic and low-level FS things are in a file called `files.js`, it basically handles just save/load TypedArrays or save/load Bitsets.

`files.js` has no notion of what is an "index", so as I did this refactor I made other parts of the code simpler, see e.g. `saveIndex(name, index)` and the updated tests.