### PR TITLE
Replace atomic-file with atomically-universal

### DIFF
--- a/files.js
+++ b/files.js
@@ -13,7 +13,9 @@ function saveTypedArrayFile(filename, seq, count, tarr, cb) {
   b.writeInt32LE(count, 4)
   dataBuffer.copy(b, 8)
 
-  writeFile(filename, b).then(cb).catch(cb)
+  writeFile(filename, b)
+    .then(() => cb())
+    .catch(cb)
 }
 
 function loadTypedArrayFile(filename, Type, cb) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/arj03/jitdb.git"
   },
   "dependencies": {
-    "atomic-file": "^2.1.1",
+    "atomically-universal": "^0.1.0",
     "binary-search-bounds": "^2.0.4",
     "bipf": "^1.3.0",
     "debug": "^4.2.0",


### PR DESCRIPTION
As the header says. Atomically should have much better error handling when running on node.

Side note: i find the auto format of promises wierd. Looks like things are floating. Anyway minor point.