### PR TITLE
prefix indexes

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,4 +1,3 @@
-const bipf = require('bipf')
 const FlumeLog = require('async-flumelog')
 const pull = require('pull-stream')
 const JITDB = require('./index')
@@ -17,7 +16,6 @@ const {
   toPullStream,
   toAsyncIter,
   descending,
-  equalViaPrefix,
 } = require('./operators')
 const { seekType, seekAuthor, seekVoteLink } = require('./test/helpers')
 
@@ -36,10 +34,15 @@ db.onReady(async () => {
   if (false)
     query(
       fromDB(db),
-      and(votes(mid)),
+      // debug(),
+      and(slowEqual('value.content.type', 'vote')),
+      // debug(),
+      and(slowEqual('value.content.vote.expression', '⛵')),
+      // debug(),
+      and(slowEqual('value.author', staltzp)),
       // debug(),
       toCallback((err, results) => {
-        console.log(JSON.stringify(results))
+        console.log(results)
       })
     )
 
@@ -69,9 +72,8 @@ db.onReady(async () => {
     const results = await query(
       fromDB(db),
       or(
-        // slowEqualViaPrefix('value.content.vote.link', fdroidstress),
+        // slowEqual('value.content.vote.link', myroot, { prefix: 32 })
         equal(seekVoteLink, myroot, { prefix: 32, indexType: 'vote_link' })
-        // slowEqual('value.content.vote.link', fdroidstress)
       ),
       toPromise()
     )
@@ -79,50 +81,6 @@ db.onReady(async () => {
     console.log(`duration = ${duration}ms`)
     console.log(results.length)
   }
-
-  var i = 0
-  if (true) {
-    const before = Date.now()
-    const results = await query(
-      fromDB(db),
-      or(
-        // slowEqualViaPrefix('value.content.vote.link', fdroidstress),
-        equalViaPrefix(seekVoteLink, myroot, 'vote_link')
-        // slowEqual('value.content.vote.link', fdroidstress)
-      ),
-      toPromise()
-    )
-    const duration = Date.now() - before
-    console.log(`duration = ${duration}ms`)
-    console.log(results.length)
-  }
-
-  var i = 0
-  // const before = Date.now()
-  if (false)
-    pull(
-      query(
-        fromDB(db),
-        or(
-          slowStartsWith('value.content.vote.link', myroot)
-          // slowEqual('value.content.vote.link', fdroidstress)
-        ),
-        // and(equal(seek, [0], 'bit')),
-        descending(),
-        toPullStream()
-      ),
-      // pull.take(4),
-      pull.collect((err, results) => {
-        const duration = Date.now() - before
-        console.log(`duration = ${duration}ms`)
-        console.log(results.length)
-      })
-      // pull.drain((msg) => {
-      // console.log(JSON.stringify(msg) + '\n\n')
-      // })
-    )
-  // const msgKeyBin = tobin(Buffer.from(msg.key, 'base64'))
-  // console.log(msg.key + ' ' + msgKeyBin + '\n')
 
   var i = 0
   if (false) {

--- a/example.js
+++ b/example.js
@@ -9,7 +9,6 @@ const {
   or,
   slowEqual,
   equal,
-  slowEqualViaPrefix,
   debug,
   author,
   paginate,
@@ -49,12 +48,31 @@ db.onReady(async () => {
     const results = await query(
       fromDB(db),
       // debug(),
-      and(equal(seekType, 'blog', 'type')),
+      and(equal(seekType, 'blog', { indexType: 'type' })),
       // debug(),
       and(
-        or(equal(seekAuthor, mix, 'author'), equal(seekAuthor, mixy, 'author'))
+        or(
+          equal(seekAuthor, mix, { indexType: 'author' }),
+          equal(seekAuthor, mixy, { indexType: 'author' })
+        )
       ),
       // debug(),
+      toPromise()
+    )
+    const duration = Date.now() - before
+    console.log(`duration = ${duration}ms`)
+    console.log(results.length)
+  }
+
+  if (true) {
+    const before = Date.now()
+    const results = await query(
+      fromDB(db),
+      or(
+        // slowEqualViaPrefix('value.content.vote.link', fdroidstress),
+        equal(seekVoteLink, myroot, { prefix: 32, indexType: 'vote_link' })
+        // slowEqual('value.content.vote.link', fdroidstress)
+      ),
       toPromise()
     )
     const duration = Date.now() - before

--- a/index.js
+++ b/index.js
@@ -495,7 +495,7 @@ module.exports = function (log, indexesPath) {
     const target = op.data.value
     const targetPrefix = target.readUInt32LE(0)
     const prefixIndex = indexes[op.data.indexName]
-    for (let i = 0, len = prefixIndex.tarr.length; i < len; ++i) {
+    for (let i = 0; i < prefixIndex.count; ++i) {
       if (prefixIndex.tarr[i] === targetPrefix) bitset.add(i)
     }
     const getRec = promisify(getRecord)

--- a/index.js
+++ b/index.js
@@ -241,8 +241,7 @@ module.exports = function (log, indexesPath) {
   }
 
   function updateIndexValue(opData, index, buffer, offset) {
-    const status = checkValue(opData, buffer)
-    if (status) index.bitset.add(offset)
+    if (checkValue(opData, buffer)) index.bitset.add(offset)
   }
 
   function updateAllIndexValue(opData, newIndexes, buffer, offset) {

--- a/index.js
+++ b/index.js
@@ -493,7 +493,7 @@ module.exports = function (log, indexesPath) {
     })
   }
 
-  async function matchAgainstPrefix(op, cb) {
+  function matchAgainstPrefix(op, cb) {
     const bitset = new TypedFastBitSet()
     const target = op.data.value
     const targetPrefix = target.readUInt32LE(0)

--- a/index.js
+++ b/index.js
@@ -153,13 +153,8 @@ module.exports = function (log, indexesPath) {
   }
 
   function growTarrIndex(index, Type) {
-    let newLength = index.tarr.length * 2
-    // FIXME: even better would be to bring back the exponential jumps, but
-    // when reaching the end of the log stream, cut off all the empty space
-    const diff = Math.min(newLength - index.tarr.length, 64000)
-    newLength = index.tarr.length + diff
-    debug('growing index by +%d', diff)
-    const newArray = new Type(newLength)
+    debug('growing index')
+    const newArray = new Type(index.tarr.length * 2)
     newArray.set(index.tarr)
     index.tarr = newArray
   }

--- a/index.js
+++ b/index.js
@@ -461,8 +461,12 @@ module.exports = function (log, indexesPath) {
   }
 
   function ensureIndexSync(op, cb) {
-    if (log.since.value > indexes[op.data.indexName].seq) updateIndex(op, cb)
-    else cb()
+    if (log.since.value > indexes[op.data.indexName].seq) {
+      updateIndex(op, cb)
+    } else {
+      debug('ensureIndexSync %s is already synced', op.data.indexName)
+      cb()
+    }
   }
 
   function ensureOffsetIndexSync(cb) {

--- a/operators.js
+++ b/operators.js
@@ -56,7 +56,8 @@ function seekFromDesc(desc) {
   }
 }
 
-function slowEqual(seekDesc, value, indexAll) {
+function slowEqual(seekDesc, value, opts) {
+  opts = opts || {}
   const indexType = seekDesc.replace(/\./g, '_')
   const seek = seekFromDesc(seekDesc)
   return {
@@ -65,45 +66,22 @@ function slowEqual(seekDesc, value, indexAll) {
       seek,
       value: toBuffer(value),
       indexType,
-      indexAll,
+      indexAll: opts.indexAll,
+      prefix: opts.prefix,
     },
   }
 }
 
-function equal(seek, value, indexType, indexAll) {
+function equal(seek, value, opts) {
+  opts = opts || {}
   return {
     type: 'EQUAL',
     data: {
       seek,
       value: toBuffer(value),
-      indexType,
-      indexAll,
-    },
-  }
-}
-
-function slowEqualViaPrefix(seekDesc, value, indexAll) {
-  const indexType = seekDesc.replace(/\./g, '_')
-  const seek = seekFromDesc(seekDesc)
-  return {
-    type: 'EQUAL',
-    data: {
-      seek,
-      value: toBuffer(value),
-      indexType,
-      prefix: 32,
-    },
-  }
-}
-
-function equalViaPrefix(seek, value, indexType, indexAll) {
-  return {
-    type: 'EQUAL',
-    data: {
-      seek,
-      value: toBuffer(value),
-      indexType,
-      prefix: 32,
+      indexType: opts.indexType,
+      indexAll: opts.indexAll,
+      prefix: opts.prefix,
     },
   }
 }
@@ -358,8 +336,6 @@ module.exports = {
   live,
   slowEqual,
   equal,
-  equalViaPrefix,
-  slowEqualViaPrefix,
   gt,
   gte,
   lt,

--- a/operators.js
+++ b/operators.js
@@ -62,7 +62,7 @@ function slowEqual(seekDesc, value, indexAll) {
   return {
     type: 'EQUAL',
     data: {
-      seek: seek,
+      seek,
       value: toBuffer(value),
       indexType,
       indexAll,
@@ -74,10 +74,36 @@ function equal(seek, value, indexType, indexAll) {
   return {
     type: 'EQUAL',
     data: {
-      seek: seek,
+      seek,
       value: toBuffer(value),
       indexType,
       indexAll,
+    },
+  }
+}
+
+function slowEqualViaPrefix(seekDesc, value, indexAll) {
+  const indexType = seekDesc.replace(/\./g, '_')
+  const seek = seekFromDesc(seekDesc)
+  return {
+    type: 'EQUAL',
+    data: {
+      seek,
+      value: toBuffer(value),
+      indexType,
+      prefix: 32,
+    },
+  }
+}
+
+function equalViaPrefix(seek, value, indexType, indexAll) {
+  return {
+    type: 'EQUAL',
+    data: {
+      seek,
+      value: toBuffer(value),
+      indexType,
+      prefix: 32,
     },
   }
 }
@@ -332,6 +358,8 @@ module.exports = {
   live,
   slowEqual,
   equal,
+  equalViaPrefix,
+  slowEqualViaPrefix,
   gt,
   gte,
   lt,

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "idb-kv-store": "^4.5.0",
     "jsesc": "^3.0.2",
     "mkdirp": "^1.0.4",
+    "multicb": "1.2.2",
     "promisify-4loc": "1.0.0",
     "pull-async": "~1.0.0",
     "pull-awaitable": "^1.0.0",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,6 +1,8 @@
 const bipf = require('bipf')
 
 const bValue = Buffer.from('value')
+const bVote = Buffer.from('vote')
+const bLink = Buffer.from('link')
 const bAuthor = Buffer.from('author')
 const bContent = Buffer.from('content')
 const bType = Buffer.from('type')
@@ -15,6 +17,17 @@ module.exports = {
     p = bipf.seekKey(buffer, p, bValue)
 
     if (~p) return bipf.seekKey(buffer, p, bAuthor)
+  },
+
+  seekVoteLink: function (buffer) {
+    var p = 0 // note you pass in p!
+    p = bipf.seekKey(buffer, p, bValue)
+    if (!~p) return
+    p = bipf.seekKey(buffer, p, bContent)
+    if (!~p) return
+    p = bipf.seekKey(buffer, p, bVote)
+    if (!~p) return
+    return bipf.seekKey(buffer, p, bLink)
   },
 
   seekType: function (buffer) {

--- a/test/operators.js
+++ b/test/operators.js
@@ -12,6 +12,8 @@ const {
   or,
   equal,
   slowEqual,
+  equalViaPrefix,
+  slowEqualViaPrefix,
   gt,
   gte,
   lt,
@@ -93,6 +95,36 @@ prepareAndRunTest('slowEqual 3 args', dir, (t, db, raf) => {
   t.equal(queryTree.data.indexAll, true)
   t.deepEqual(queryTree.data.value, Buffer.from('post'))
   t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
+
+  t.end()
+})
+
+prepareAndRunTest('equalViaPrefix', dir, (t, db, raf) => {
+  const queryTree = equalViaPrefix(helpers.seekType, 'post', 'type')
+
+  t.equal(typeof queryTree, 'object', 'queryTree is an object')
+
+  t.equal(queryTree.type, 'EQUAL')
+
+  t.equal(queryTree.data.indexType, 'type')
+  t.deepEqual(queryTree.data.value, Buffer.from('post'))
+  t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
+  t.equal(queryTree.data.prefix, 32)
+
+  t.end()
+})
+
+prepareAndRunTest('slowEqualViaPrefix', dir, (t, db, raf) => {
+  const queryTree = slowEqualViaPrefix('value.content.type', 'post', 'type')
+
+  t.equal(typeof queryTree, 'object', 'queryTree is an object')
+
+  t.equal(queryTree.type, 'EQUAL')
+
+  t.equal(queryTree.data.indexType, 'value_content_type')
+  t.deepEqual(queryTree.data.value, Buffer.from('post'))
+  t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
+  t.equal(queryTree.data.prefix, 32)
 
   t.end()
 })

--- a/test/operators.js
+++ b/test/operators.js
@@ -12,8 +12,6 @@ const {
   or,
   equal,
   slowEqual,
-  equalViaPrefix,
-  slowEqualViaPrefix,
   gt,
   gte,
   lt,
@@ -43,7 +41,7 @@ const bob = ssbKeys.generate('ed25519', Buffer.alloc(32, 'b'))
 prepareAndRunTest('operators API supports equal', dir, (t, db, raf) => {
   const queryTree = query(
     fromDB(db),
-    and(equal(helpers.seekType, 'post', 'type', true))
+    and(equal(helpers.seekType, 'post', { indexType: 'type', indexAll: true }))
   )
 
   t.equal(typeof queryTree, 'object', 'queryTree is an object')
@@ -85,7 +83,7 @@ prepareAndRunTest('operators API supports slowEqual', dir, (t, db, raf) => {
 })
 
 prepareAndRunTest('slowEqual 3 args', dir, (t, db, raf) => {
-  const queryTree = slowEqual('value.content.type', 'post', true)
+  const queryTree = slowEqual('value.content.type', 'post', { indexAll: true })
 
   t.equal(typeof queryTree, 'object', 'queryTree is an object')
 
@@ -99,8 +97,11 @@ prepareAndRunTest('slowEqual 3 args', dir, (t, db, raf) => {
   t.end()
 })
 
-prepareAndRunTest('equalViaPrefix', dir, (t, db, raf) => {
-  const queryTree = equalViaPrefix(helpers.seekType, 'post', 'type')
+prepareAndRunTest('equal with prefix', dir, (t, db, raf) => {
+  const queryTree = equal(helpers.seekType, 'post', {
+    prefix: 32,
+    indexType: 'type',
+  })
 
   t.equal(typeof queryTree, 'object', 'queryTree is an object')
 
@@ -114,8 +115,11 @@ prepareAndRunTest('equalViaPrefix', dir, (t, db, raf) => {
   t.end()
 })
 
-prepareAndRunTest('slowEqualViaPrefix', dir, (t, db, raf) => {
-  const queryTree = slowEqualViaPrefix('value.content.type', 'post', 'type')
+prepareAndRunTest('slowEqual with prefix', dir, (t, db, raf) => {
+  const queryTree = slowEqual('value.content.type', 'post', {
+    prefix: 32,
+    indexType: 'type',
+  })
 
   t.equal(typeof queryTree, 'object', 'queryTree is an object')
 
@@ -256,7 +260,10 @@ prepareAndRunTest(
 prepareAndRunTest('operator gt', dir, (t, db, raf) => {
   const queryTree = query(
     fromDB(db),
-    and(equal(helpers.seekAuthor, alice.id, 'author'), gt(2, 'sequence'))
+    and(
+      equal(helpers.seekAuthor, alice.id, { indexType: 'author' }),
+      gt(2, 'sequence')
+    )
   )
 
   t.equal(typeof queryTree, 'object', 'queryTree is an object')
@@ -279,7 +286,10 @@ prepareAndRunTest('operator gt', dir, (t, db, raf) => {
 prepareAndRunTest('operator gte', dir, (t, db, raf) => {
   const queryTree = query(
     fromDB(db),
-    and(equal(helpers.seekAuthor, alice.id, 'author'), gte(2, 'sequence'))
+    and(
+      equal(helpers.seekAuthor, alice.id, { indexType: 'author' }),
+      gte(2, 'sequence')
+    )
   )
 
   t.equal(typeof queryTree, 'object', 'queryTree is an object')
@@ -299,7 +309,10 @@ prepareAndRunTest('operator gte', dir, (t, db, raf) => {
 prepareAndRunTest('operator lt', dir, (t, db, raf) => {
   const queryTree = query(
     fromDB(db),
-    and(equal(helpers.seekAuthor, alice.id, 'author'), lt(2, 'sequence'))
+    and(
+      equal(helpers.seekAuthor, alice.id, { indexType: 'author' }),
+      lt(2, 'sequence')
+    )
   )
 
   t.equal(typeof queryTree, 'object', 'queryTree is an object')
@@ -319,7 +332,10 @@ prepareAndRunTest('operator lt', dir, (t, db, raf) => {
 prepareAndRunTest('operator lte', dir, (t, db, raf) => {
   const queryTree = query(
     fromDB(db),
-    and(equal(helpers.seekAuthor, alice.id, 'author'), lte(2, 'sequence'))
+    and(
+      equal(helpers.seekAuthor, alice.id, { indexType: 'author' }),
+      lte(2, 'sequence')
+    )
   )
 
   t.equal(typeof queryTree, 'object', 'queryTree is an object')

--- a/test/prefix.js
+++ b/test/prefix.js
@@ -1,0 +1,46 @@
+const validate = require('ssb-validate')
+const ssbKeys = require('ssb-keys')
+const path = require('path')
+const { prepareAndRunTest, addMsg, helpers } = require('./common')()
+const rimraf = require('rimraf')
+const mkdirp = require('mkdirp')
+
+const dir = '/tmp/jitdb-prefix'
+rimraf.sync(dir)
+mkdirp.sync(dir)
+
+var keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
+
+prepareAndRunTest('Prefix equal', dir, (t, db, raf) => {
+  const msg1 = { type: 'post', text: 'Testing!' }
+  const msg2 = { type: 'contact', text: 'Testing!' }
+  const msg3 = { type: 'post', text: 'Testing 2!' }
+
+  let state = validate.initial()
+  state = validate.appendNew(state, null, keys, msg1, Date.now())
+  state = validate.appendNew(state, null, keys, msg2, Date.now() + 1)
+  state = validate.appendNew(state, null, keys, msg3, Date.now() + 2)
+
+  const typeQuery = {
+    type: 'EQUAL',
+    data: {
+      seek: helpers.seekType,
+      value: 'post',
+      indexType: 'type',
+      prefix: 32,
+    },
+  }
+
+  addMsg(state.queue[0].value, raf, (err, msg) => {
+    addMsg(state.queue[1].value, raf, (err, msg) => {
+      addMsg(state.queue[2].value, raf, (err, msg) => {
+        db.all(typeQuery, 0, false, (err, results) => {
+          t.equal(results.length, 2)
+          t.equal(results[0].value.content.type, 'post')
+          t.equal(results[1].value.content.type, 'post')
+          t.end()
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
For issue #40, this is a work in progress but most of it is working.

- [x] Experiments with 8 bit, 16 bit, 32 bit
- [x] Working implementation
- [x] Benchmarks
- [x] Consider the API
- [x] Tests
- [x] Clean up code

Note about the API: I think for a long time what would be a good operator name. But it turns out that semantically this is the same as `equal`, it's just a different way of doing `equal`, so I opted for the same name, but indicating that it's using prefix indexes `equalViaPrefix`. I would maybe prefer another API: `equal(seeker, value, opts)` where `opts: {indexType, indexAll, prefix}` so to use this new algorithm you would write `equal(seekVoteLink, msgid, {prefix:true})` or `slowEqual('value.content.vote.link', msgid, {prefix:true})`

Random notes about early perf benchmarks:

```
and(blog, or(author1, author2))

  - 3 records found
  - duration when cold everything missing: 6900ms
  - duration when cold 3 missing indexes:  3000ms
  - duration when cold 2 missing indexes:  2100ms
  - duration when cold 1 missing index:    2000ms
  - duration when warm query:                20ms

votes.link=msgid (prefix 16 bits from base64 decoded)

  - 24 records found
  - duration when cold everything missing:   5300ms
  - duration when cold prefix index missing: 4000ms
  - duration when warm query:                  50ms

slowEqualViaPrefix votes.link=msgid (prefix 32 bits from base64 as is in log.bipf)

  - 17 records found, some are false positives
  - duration when cold everything missing:   4800ms
  - duration when cold prefix index missing: 3300ms
  - duration when warm query:                  40ms

equalViaPrefix votes.link=msgid (prefix 32 bits from base64 as is in log.bipf)

  - 17 records found, some are false positives
  - duration when cold everything missing:   3600ms
  - duration when cold prefix index missing: 2000ms
  - duration when warm query:                  30ms

equalViaPrefix votes.link=msgid (prefix 32 bits from base64 as is in log.bipf)
with additional iteration over the results to remove false positives

  - 15 records found
  - duration when cold everything missing:   4600ms
  - duration when cold prefix index missing: 2100ms
  - duration when warm query:                  40ms
```

The prefix index file is the same size as the `offset.index` and `sequence.index`, roughly ~5MB for a production dataset.