### PR TITLE
cut off empty space when saving tarr file

### DIFF
--- a/files.js
+++ b/files.js
@@ -8,7 +8,7 @@ function saveTypedArrayFile(filename, seq, count, tarr, cb) {
   if (!cb) cb = () => {}
 
   const dataBuffer = toBuffer(tarr)
-  const b = Buffer.alloc(8 + dataBuffer.length)
+  const b = Buffer.alloc(8 + count * tarr.BYTES_PER_ELEMENT)
   b.writeInt32LE(seq, 0)
   b.writeInt32LE(count, 4)
   dataBuffer.copy(b, 8)

--- a/test/save-load.js
+++ b/test/save-load.js
@@ -14,6 +14,12 @@ const dir = '/tmp/jitdb-save-load'
 rimraf.sync(dir)
 mkdirp.sync(dir)
 
+function growTarrIndex(index, Type) {
+  const newArray = new Type(index.tarr.length * 2)
+  newArray.set(index.tarr)
+  index.tarr = newArray
+}
+
 test('save and load bitsets', (t) => {
   const idxDir = path.join(dir, 'test-bitsets')
   mkdirp.sync(idxDir)
@@ -51,8 +57,12 @@ test('save and load TypedArray for offset', (t) => {
 
   saveTypedArrayFile(filename, 123, 10, tarr, (err) => {
     loadTypedArrayFile(filename, Uint32Array, (err, loadedIdx) => {
+      t.equal(loadedIdx.tarr.length, 10, 'file trimmed')
+
       for (var i = 0; i < 10; i += 1) t.equal(tarr[i], loadedIdx.tarr[i])
 
+      // we need some more space
+      growTarrIndex(loadedIdx, Uint32Array)
       loadedIdx.tarr[10] = 10
 
       saveTypedArrayFile(filename, 1234, 11, loadedIdx.tarr, (err) => {
@@ -78,6 +88,7 @@ test('save and load TypedArray for timestamp', (t) => {
     loadTypedArrayFile(filename, Float64Array, (err, loadedIdx) => {
       for (var i = 0; i < 10; i += 1) t.equal(tarr[i], loadedIdx.tarr[i])
 
+      growTarrIndex(loadedIdx, Float64Array)
       loadedIdx.tarr[10] = 10 * 1000000
 
       saveTypedArrayFile(filename, 1234, 11, loadedIdx.tarr, (err) => {


### PR DESCRIPTION
Reduces about 35% of the file size, which is some megabytes.

before

```
drwxrwxr-x 2 staltz staltz     4096 joulu  3 16:51  .
drwxr-xr-x 8 staltz staltz     4096 joulu  3 16:51  ..
-rw-rw-r-- 1 staltz staltz  8192008 joulu  3 16:51  offset.index
-rw-rw-r-- 1 staltz staltz  8192008 joulu  3 16:51  sequence.index
-rw-rw-r-- 1 staltz staltz 16384008 joulu  3 16:51  timestamp.index
```

after

```
drwxrwxr-x 2 staltz staltz     4096 joulu  3 16:52  .
drwxr-xr-x 8 staltz staltz     4096 joulu  3 16:52  ..
-rw-rw-r-- 1 staltz staltz  5330716 joulu  3 16:52  offset.index
-rw-rw-r-- 1 staltz staltz  5330716 joulu  3 16:52  sequence.index
-rw-rw-r-- 1 staltz staltz 10661424 joulu  3 16:52  timestamp.index
```