### PR TITLE
When saving leave 10% empty space

### DIFF
--- a/files.js
+++ b/files.js
@@ -8,7 +8,10 @@ function saveTypedArrayFile(filename, seq, count, tarr, cb) {
   if (!cb) cb = () => {}
 
   const dataBuffer = toBuffer(tarr)
-  const b = Buffer.alloc(8 + count * tarr.BYTES_PER_ELEMENT)
+  // we try to save an extra 10% so we don't have to immediately grow
+  // after loading and adding again
+  const saveSize = Math.min(count * 1.1, tarr.length)
+  const b = Buffer.alloc(8 + saveSize * tarr.BYTES_PER_ELEMENT)
   b.writeInt32LE(seq, 0)
   b.writeInt32LE(count, 4)
   dataBuffer.copy(b, 8)

--- a/test/save-load.js
+++ b/test/save-load.js
@@ -14,12 +14,6 @@ const dir = '/tmp/jitdb-save-load'
 rimraf.sync(dir)
 mkdirp.sync(dir)
 
-function growTarrIndex(index, Type) {
-  const newArray = new Type(index.tarr.length * 2)
-  newArray.set(index.tarr)
-  index.tarr = newArray
-}
-
 test('save and load bitsets', (t) => {
   const idxDir = path.join(dir, 'test-bitsets')
   mkdirp.sync(idxDir)
@@ -57,12 +51,10 @@ test('save and load TypedArray for offset', (t) => {
 
   saveTypedArrayFile(filename, 123, 10, tarr, (err) => {
     loadTypedArrayFile(filename, Uint32Array, (err, loadedIdx) => {
-      t.equal(loadedIdx.tarr.length, 10, 'file trimmed')
+      t.equal(loadedIdx.tarr.length, 10 * 1.1, 'file trimmed')
 
       for (var i = 0; i < 10; i += 1) t.equal(tarr[i], loadedIdx.tarr[i])
 
-      // we need some more space
-      growTarrIndex(loadedIdx, Uint32Array)
       loadedIdx.tarr[10] = 10
 
       saveTypedArrayFile(filename, 1234, 11, loadedIdx.tarr, (err) => {
@@ -88,7 +80,6 @@ test('save and load TypedArray for timestamp', (t) => {
     loadTypedArrayFile(filename, Float64Array, (err, loadedIdx) => {
       for (var i = 0; i < 10; i += 1) t.equal(tarr[i], loadedIdx.tarr[i])
 
-      growTarrIndex(loadedIdx, Float64Array)
       loadedIdx.tarr[10] = 10 * 1000000
 
       saveTypedArrayFile(filename, 1234, 11, loadedIdx.tarr, (err) => {


### PR DESCRIPTION
This is a continuation of #53. We don't want to have to immediate grow the log again after loading, especially not to double the size ;) This still saves significantly. 8mb to 6.3mb per file for me.