### PR TITLE
Falsy targets

### DIFF
--- a/operators.js
+++ b/operators.js
@@ -104,6 +104,7 @@ function equal(seek, target, opts) {
 }
 
 function gt(value, indexName) {
+  if (typeof value !== 'number') throw new Error('gt() needs a number arg')
   return {
     type: 'GT',
     data: {
@@ -114,6 +115,7 @@ function gt(value, indexName) {
 }
 
 function gte(value, indexName) {
+  if (typeof value !== 'number') throw new Error('gte() needs a number arg')
   return {
     type: 'GTE',
     data: {
@@ -124,6 +126,7 @@ function gte(value, indexName) {
 }
 
 function lt(value, indexName) {
+  if (typeof value !== 'number') throw new Error('lt() needs a number arg')
   return {
     type: 'LT',
     data: {
@@ -134,6 +137,7 @@ function lt(value, indexName) {
 }
 
 function lte(value, indexName) {
+  if (typeof value !== 'number') throw new Error('lte() needs a number arg')
   return {
     type: 'LTE',
     data: {

--- a/test/add.js
+++ b/test/add.js
@@ -6,6 +6,7 @@ const { prepareAndRunTest, addMsg, helpers } = require('./common')()
 const push = require('push-stream')
 const rimraf = require('rimraf')
 const mkdirp = require('mkdirp')
+const { safeFilename } = require('../files')
 
 const dir = '/tmp/jitdb-add'
 rimraf.sync(dir)
@@ -25,8 +26,9 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: 'post',
+      value: Buffer.from('post'),
       indexType: 'type',
+      indexName: 'type_post',
     },
   }
 
@@ -48,8 +50,9 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
               type: 'EQUAL',
               data: {
                 seek: helpers.seekAuthor,
-                value: keys.id,
+                value: Buffer.from(keys.id),
                 indexType: 'author',
+                indexName: 'author_' + keys.id,
               },
             }
             db.paginate(authorQuery, 0, 10, false, (err, { results }) => {
@@ -77,8 +80,9 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
                       type: 'EQUAL',
                       data: {
                         seek: helpers.seekAuthor,
-                        value: keys2.id,
+                        value: Buffer.from(keys2.id),
                         indexType: 'author',
+                        indexName: 'author_' + keys2.id,
                       },
                     }
 
@@ -122,8 +126,9 @@ prepareAndRunTest('Update index', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: 'post',
+      value: Buffer.from('post'),
       indexType: 'type',
+      indexName: 'type_post',
     },
   }
 
@@ -154,8 +159,9 @@ prepareAndRunTest('grow', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: 'post',
+      value: Buffer.from('post'),
       indexType: 'type',
+      indexName: 'type_post',
     },
   }
 
@@ -192,17 +198,19 @@ prepareAndRunTest('indexAll', dir, (t, db, raf) => {
         type: 'EQUAL',
         data: {
           seek: helpers.seekType,
-          value: 'post',
+          value: Buffer.from('post'),
           indexType: 'type',
+          indexName: 'type_post',
         },
       },
       {
         type: 'EQUAL',
         data: {
           seek: helpers.seekAuthor,
-          value: keys.id,
+          value: Buffer.from(keys.id),
           indexType: 'author',
           indexAll: true,
+          indexName: safeFilename('author_' + keys.id),
         },
       },
     ],
@@ -213,6 +221,7 @@ prepareAndRunTest('indexAll', dir, (t, db, raf) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
         addMsg(state.queue[3].value, raf, (err, msg) => {
           db.all(authorQuery, 0, false, (err, results) => {
+            t.error(err)
             t.equal(results.length, 1)
             t.equal(results[0].value.content.text, 'Testing 1')
             t.equal(Object.keys(db.indexes).length, 3 + 2 + 1 + 1)
@@ -240,9 +249,10 @@ prepareAndRunTest('indexAll multiple reindexes', dir, (t, db, raf) => {
       type: 'EQUAL',
       data: {
         seek: helpers.seekType,
-        value,
+        value: Buffer.from(value),
         indexType: 'type',
         indexAll: true,
+        indexName: safeFilename('type_' + value),
       },
     }
   }

--- a/test/del.js
+++ b/test/del.js
@@ -25,8 +25,9 @@ prepareAndRunTest('Delete', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: 'post',
+      value: Buffer.from('post'),
       indexType: 'type',
+      indexName: 'type_post',
     },
   }
 

--- a/test/live.js
+++ b/test/live.js
@@ -25,8 +25,9 @@ prepareAndRunTest('Live', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: 'post',
+      value: Buffer.from('post'),
       indexType: 'type',
+      indexName: 'type_post',
     },
   }
 
@@ -63,16 +64,18 @@ prepareAndRunTest('Live and', dir, (t, db, raf) => {
         type: 'EQUAL',
         data: {
           seek: helpers.seekAuthor,
-          value: keys.id,
+          value: Buffer.from(keys.id),
           indexType: 'author',
+          indexName: 'author_' + keys.id,
         },
       },
       {
         type: 'EQUAL',
         data: {
           seek: helpers.seekType,
-          value: 'post',
+          value: Buffer.from('post'),
           indexType: 'type',
+          indexName: 'type_post',
         },
       },
     ],
@@ -116,16 +119,18 @@ prepareAndRunTest('Live or', dir, (t, db, raf) => {
         type: 'EQUAL',
         data: {
           seek: helpers.seekAuthor,
-          value: keys.id,
+          value: Buffer.from(keys.id),
           indexType: 'author',
+          indexName: 'author_' + keys.id,
         },
       },
       {
         type: 'EQUAL',
         data: {
           seek: helpers.seekAuthor,
-          value: keys2.id,
+          value: Buffer.from(keys2.id),
           indexType: 'author',
+          indexName: 'author_' + keys2.id,
         },
       },
     ],
@@ -139,8 +144,9 @@ prepareAndRunTest('Live or', dir, (t, db, raf) => {
         type: 'EQUAL',
         data: {
           seek: helpers.seekType,
-          value: 'post',
+          value: Buffer.from('post'),
           indexType: 'type',
+          indexName: 'type_post',
         },
       },
     ],
@@ -183,8 +189,9 @@ prepareAndRunTest('Live with initial values', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: 'post',
+      value: Buffer.from('post'),
       indexType: 'type',
+      indexName: 'type_post',
     },
   }
 
@@ -242,8 +249,9 @@ prepareAndRunTest('Live with offset values', dir, (t, db, raf) => {
         type: 'EQUAL',
         data: {
           seek: helpers.seekType,
-          value: 'post',
+          value: Buffer.from('post'),
           indexType: 'type',
+          indexName: 'type_post',
         },
       },
       {
@@ -284,8 +292,9 @@ prepareAndRunTest('Live with cleanup', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: 'post',
+      value: Buffer.from('post'),
       indexType: 'type',
+      indexName: 'type_post',
     },
   }
 

--- a/test/operators.js
+++ b/test/operators.js
@@ -384,6 +384,23 @@ prepareAndRunTest('operator lte', dir, (t, db, raf) => {
   t.end()
 })
 
+prepareAndRunTest('operators gt lt gte lte numbers only', dir, (t, db, raf) => {
+  t.throws(() => {
+    gt('2', 'sequence')
+  })
+  t.throws(() => {
+    lt('2', 'sequence')
+  })
+  t.throws(() => {
+    gte('2', 'sequence')
+  })
+  t.throws(() => {
+    lte('2', 'sequence')
+  })
+
+  t.end()
+})
+
 prepareAndRunTest('operator offsets', dir, (t, db, raf) => {
   const queryTree = query(fromDB(db), and(offsets([10, 20])))
 

--- a/test/operators.js
+++ b/test/operators.js
@@ -97,6 +97,38 @@ prepareAndRunTest('slowEqual 3 args', dir, (t, db, raf) => {
   t.end()
 })
 
+prepareAndRunTest('equal with null value', dir, (t, db, raf) => {
+  const queryTree = equal(helpers.seekChannel, null, {
+    indexType: 'channel',
+  })
+
+  t.equal(typeof queryTree, 'object', 'queryTree is an object')
+
+  t.equal(queryTree.type, 'EQUAL')
+
+  t.equal(queryTree.data.indexType, 'channel')
+  t.notOk(queryTree.data.value)
+  t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
+
+  t.end()
+})
+
+prepareAndRunTest('equal with undefined value', dir, (t, db, raf) => {
+  const queryTree = equal(helpers.seekChannel, undefined, {
+    indexType: 'channel',
+  })
+
+  t.equal(typeof queryTree, 'object', 'queryTree is an object')
+
+  t.equal(queryTree.type, 'EQUAL')
+
+  t.equal(queryTree.data.indexType, 'channel')
+  t.notOk(queryTree.data.value)
+  t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
+
+  t.end()
+})
+
 prepareAndRunTest('equal with prefix', dir, (t, db, raf) => {
   const queryTree = equal(helpers.seekType, 'post', {
     prefix: 32,


### PR DESCRIPTION
Problem: `isRoot()` in db2 wasn't working, not even in the `master` branch, and that's because jitdb needed these fixes. And when moving `isRoot()` to prefix, we would need even more changes to jitdb.

It's about `op.data.value` being undefined, and having logic that checks that when doing the queries.

This PR does a couple of other stuff too, e.g. I noticed that there is a duplicate logic `Buffer.isBuffer(x) ? x : Buffer.from(x)`: (1) in operators, (2) in sanitizeOpData. I ended up removing sanitizeOpData completely, and putting all "sanitization" logic in the operators, including `indexName`. This made `index.js` a bit simpler to work with, we can trust that when we get the operation object, it is ready for use.

Finally, I wanted to add support for `op.data.value === null` too, because eventually someone will write a query using db2 that has null, and it would be good if this wouldn't crash jitdb. So checking for absence is now done with any falsy value.