### PR TITLE
tiny performance tweaks to for loops

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "url": "git://github.com/arj03/jitdb.git"
   },
   "dependencies": {
+    "@staltz/bipf": "^1.4.0",
     "atomically-universal": "^0.1.0",
     "binary-search-bounds": "^2.0.4",
-    "@staltz/bipf": "^1.4.0",
     "debug": "^4.2.0",
     "idb-kv-store": "^4.5.0",
     "jsesc": "^3.0.2",
@@ -21,8 +21,8 @@
     "pull-awaitable": "^1.0.0",
     "pull-cat": "~1.1.11",
     "pull-stream": "^3.6.14",
-    "push-stream": "^11.0.0",
     "push-stream-to-pull-stream": "^1.0.3",
+    "push-stream": "^11.0.0",
     "sanitize-filename": "^1.6.3",
     "traverse": "^0.6.6",
     "typedarray-to-buffer": "^3.1.5",


### PR DESCRIPTION
"Make it work, make it right, make it fast", this is the 3rd kind. Will hardly be a significant improvement, so I'm doing it only now that I consider jitdb mostly done. Just polishing the for loops that are in hot paths, to avoid a few extra costs, like dot chaining, etc.

## Benchmark before

```
  generate fixture with flumelog-offset

    ✔ seed = sloop
    ✔ messages = 100000
    ✔ authors = 2000
    ✔ log.offset was created

  move flumelog-offset to async-flumelog

    ✔ log.bipf was created

  core indexes

    ✔ duration: 7ms

  query one huge index (first run)

    ✔ duration: 600ms

  query one huge index (second run)

    ✔ duration: 307ms

  query three indexes (first run)

    ✔ duration: 462ms

  query three indexes (second run)

    ✔ duration: 206ms


  total:     10
  passing:   10
  duration:  1m 59.9s
```

## Benchmark after

```
  generate fixture with flumelog-offset

    ✔ seed = sloop
    ✔ messages = 100000
    ✔ authors = 2000
    ✔ log.offset was created

  move flumelog-offset to async-flumelog

    ✔ log.bipf was created

  core indexes

    ✔ duration: 8ms

  query one huge index (first run)

    ✔ duration: 584ms

  query one huge index (second run)

    ✔ duration: 263ms

  query three indexes (first run)

    ✔ duration: 417ms

  query three indexes (second run)

    ✔ duration: 239ms


  total:     10
  passing:   10
  duration:  1m 59.4s
```
