### PR TITLE
optimize performance of paginate()

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,15 @@ const {
 module.exports = function (log, indexesPath) {
   debug('indexes path', indexesPath)
 
+  let bitsetCache = new WeakMap()
+  let sortedCache = { ascending: new WeakMap(), descending: new WeakMap() }
+
+  log.since(() => {
+    bitsetCache = new WeakMap()
+    sortedCache.ascending = new WeakMap()
+    sortedCache.descending = new WeakMap()
+  })
+
   const indexes = {}
   let isReady = false
   let waiting = []
@@ -627,6 +636,8 @@ module.exports = function (log, indexesPath) {
   }
 
   function executeOperation(operation, cb) {
+    if (bitsetCache.has(operation)) return cb(bitsetCache.get(operation))
+
     const opsMissingIndexes = []
     const lazyIndexes = []
 
@@ -649,7 +660,10 @@ module.exports = function (log, indexesPath) {
     }
 
     function getBitset() {
-      getBitsetForOperation(operation, cb)
+      getBitsetForOperation(operation, (bitset) => {
+        bitsetCache.set(operation, bitset)
+        cb(bitset)
+      })
     }
 
     function createMissingIndexes() {
@@ -703,10 +717,9 @@ module.exports = function (log, indexesPath) {
     })
   }
 
-  function getMessagesFromBitsetSlice(bitset, offset, limit, descending, cb) {
-    offset = offset || 0
-    const start = Date.now()
-
+  function sortedByTimestamp(bitset, descending) {
+    const order = descending ? 'descending' : 'ascending'
+    if (sortedCache[order].has(bitset)) return sortedCache[order].get(bitset)
     const timestamped = bitset.array().map((o) => {
       return {
         offset: o,
@@ -717,6 +730,15 @@ module.exports = function (log, indexesPath) {
       if (descending) return b.timestamp - a.timestamp
       else return a.timestamp - b.timestamp
     })
+    sortedCache[order].set(bitset, sorted)
+    return sorted
+  }
+
+  function getMessagesFromBitsetSlice(bitset, offset, limit, descending, cb) {
+    offset = offset || 0
+    const start = Date.now()
+
+    const sorted = sortedByTimestamp(bitset, descending)
     const sliced =
       limit != null
         ? sorted.slice(offset, offset + limit)
@@ -731,7 +753,7 @@ module.exports = function (log, indexesPath) {
       push.collect((err, results) => {
         cb(err, {
           results: results,
-          total: timestamped.length,
+          total: sorted.length,
           duration: Date.now() - start,
         })
       })

--- a/test/query.js
+++ b/test/query.js
@@ -307,7 +307,7 @@ prepareAndRunTest('GT,GTE,LT,LTE', dir, (t, db, raf) => {
   state = validate.appendNew(state, null, keys, msg3, Date.now() + 2)
   state = validate.appendNew(state, null, keys, msg4, Date.now() + 3)
 
-  const filterQuery = {
+  let filterQuery = {
     type: 'AND',
     data: [
       {
@@ -340,17 +340,23 @@ prepareAndRunTest('GT,GTE,LT,LTE', dir, (t, db, raf) => {
             t.equal(results[0].value.content.text, '2')
 
             filterQuery.data[0].type = 'GTE'
+            // clone to force cache invalidation inside db.all:
+            filterQuery = Object.assign({}, filterQuery)
             db.all(filterQuery, 0, false, (err, results) => {
               t.equal(results.length, 4)
               t.equal(results[0].value.content.text, '1')
 
               filterQuery.data[0].type = 'LT'
               filterQuery.data[0].data.value = 3
+              // clone to force cache invalidation inside db.all:
+              filterQuery = Object.assign({}, filterQuery)
               db.all(filterQuery, 0, false, (err, results) => {
                 t.equal(results.length, 2)
                 t.equal(results[0].value.content.text, '1')
 
                 filterQuery.data[0].type = 'LTE'
+                // clone to force cache invalidation inside db.all:
+                filterQuery = Object.assign({}, filterQuery)
                 db.all(filterQuery, 0, false, (err, results) => {
                   t.equal(results.length, 3)
                   t.equal(results[0].value.content.text, '1')
@@ -358,6 +364,8 @@ prepareAndRunTest('GT,GTE,LT,LTE', dir, (t, db, raf) => {
                   filterQuery.data[0].type = 'GT'
                   filterQuery.data[0].data.indexName = 'timestamp'
                   filterQuery.data[0].data.value = dbMsg1.value.timestamp
+                  // clone to force cache invalidation inside db.all:
+                  filterQuery = Object.assign({}, filterQuery)
                   db.all(filterQuery, 0, false, (err, results) => {
                     t.equal(results.length, 3)
                     t.equal(results[0].value.content.text, '2')


### PR DESCRIPTION
Closes #64 

This one was a clear win. Certainly sorting large arrays is expensive, and this doesn't happen with all queries, but should happen when running paginate on a huge collection, which is fairly common (give me all posts, paginated). The trick here was to reuse the output of some processing tasks. WeakMap here is really a gem, it's the first time I've used it in real world, and I've been wanting to find use cases for it for a long time.

There's two processing tasks I looked at optimizing:

- executeOperation (essentially `ops` => `bitset`)
- getMessagesFromBitsetSlice (`bitset` => `sortedTimestamps` then for each array item, getMessage)

Basically we just need to optimize for the second, because it does the sort. The first one is fast enough, but to properly optimize the second, we basically have to optimize the first. Keep reading.

Given two identical bitsets, their corresponding sorted timestamp arrays will be the same, so it makes sense to create a cache `bitset` => `sortedTimestamps`. However, how do you uniquely identify bitsets? I looked at `toString`, and for huge bitsets, it creates huge strings, that's a no go. I thought about comparing bitsets with `bitset.equal(another)`, but then we have to compare 1 with all the others in the cache, to see if it already exists. All that isn't great. But WeakMaps and Maps can take any object **as the key**, so if the bitset object was the exact same, then it makes sense to use the whole bitset object as the cache key, and not `bitset.toString`. Which brings us to the first one on that list above:

I needed a way to have consistently the same bitset object returned when internally doing `db.paginate`, and this means we shouldn't rebuild the bitset using those for-loops. That's why I needed a cache `ops` => `bitset`, which was built in the same way as above: the whole `ops` object is considered the key, we don't need to "hash" the ops object (also, the hashing process would consume time). The `ops` object given to `db.paginate` **could be a different** object with the same **contents**, but if we use `toPullStream` or `toAsyncIter`, then according to the implementation of `toPullStream`, the exact same `ops` object will be given to `db.paginate`. This is what makes it possible to use `ops` object as key for the cache.

**Memory?** In case you're wondering about the additional memory costs of using WeakMaps, check the bottom of this post, you'll be quite surprised.

**Downsides?** Check one updated test. Basically this means we cannot mutate an `ops` object and pass it again to `db.paginate` or `db.all`, the objects have to be different if their contents are different (i.e. immutable). But this is not a problem if we use `query()` and the operator functions, because they create immutable objects, same case as with `db.query` in ssb-db2.

So there are basically two caches using WeakMap. Another thing I had to add was clearing these caches entirely when the log grows, because that means `ops` will correspond to a (slightly) different `bitset`, and so forth. The performance gains are very sweet. There are no performance changes when running `npm run benchmark`, because that code doesn't do `toPullStream`, it only does `toCallback`. But the following benchmark code uses `toPullStream` on a huge collection of msgs.

## Performance

### Benchmark code:

```js
pull(
  query(
    fromDB(db),
    and(equal(seekType, 'post', { indexType: 'type' })),
    paginate(1),
    toPullStream()
  ),
  pull.drain(msgs => {
    console.log('page #' + i++)
    if (page === 10) process.exit(0)
  })
)
```

Also:

```diff
  function paginate(operation, offset, limit, descending, cb) {
+   console.time('operations=>bitset')
    onReady(() => {
      executeOperation(operation, (bitset) => {
+       console.timeEnd('operations=>bitset')
+       console.time('bitset=>sort=>msgs')
        getMessagesFromBitsetSlice(
          bitset,
          offset,
          limit,
          descending,
          (err, answer) => {
+           console.timeEnd('bitset=>sort=>msgs')
            if (err) cb(err)
            else {
              debug(
                `paginate(): ${answer.duration}ms, total messages: ${answer.total}`
              )
              cb(err, answer)
            }
          }
        )
      })
    })
  }
```

### Performance before

```
page #0
operations=>bitset: 1.149ms
bitset=>sort=>msgs: 379.539ms
page #1
operations=>bitset: 0.024ms
bitset=>sort=>msgs: 231.029ms
page #2
operations=>bitset: 0.010ms
bitset=>sort=>msgs: 176.130ms
page #3
operations=>bitset: 0.010ms
bitset=>sort=>msgs: 240.644ms
page #4
operations=>bitset: 0.010ms
bitset=>sort=>msgs: 177.296ms
page #5
operations=>bitset: 0.009ms
bitset=>sort=>msgs: 211.052ms
page #6
operations=>bitset: 0.012ms
bitset=>sort=>msgs: 174.583ms
page #7
operations=>bitset: 0.010ms
bitset=>sort=>msgs: 177.841ms
page #8
operations=>bitset: 0.011ms
bitset=>sort=>msgs: 239.236ms
page #9
operations=>bitset: 0.012ms
bitset=>sort=>msgs: 175.913ms
```

### Performance after

```
page #0
operations=>bitset: 1.292ms
bitset=>sort=>msgs: 376.668ms
page #1
operations=>bitset: 0.073ms
bitset=>sort=>msgs: 2.596ms
page #2
operations=>bitset: 0.008ms
bitset=>sort=>msgs: 0.095ms
page #3
operations=>bitset: 0.004ms
bitset=>sort=>msgs: 0.348ms
page #4
operations=>bitset: 0.004ms
bitset=>sort=>msgs: 0.076ms
page #5
operations=>bitset: 0.003ms
bitset=>sort=>msgs: 0.089ms
page #6
operations=>bitset: 0.004ms
bitset=>sort=>msgs: 0.183ms
page #7
operations=>bitset: 0.004ms
bitset=>sort=>msgs: 0.151ms
page #8
operations=>bitset: 0.004ms
bitset=>sort=>msgs: 0.144ms
page #9
operations=>bitset: 0.004ms
bitset=>sort=>msgs: 0.127ms
```

## Memory

Basically the new method with WeakMap uses *less memory* overall and causes *less GCs*, that's because we're not allocating new stuff for this cache, we're taking the same objects that would already exist (without this cache), and we're using them as keys and values. Plus, because this is a WeakMap and not a Map, when GC wants to run (e.g. some time after toPullStream has completed draining), the pointers in the WeakMap will not block the GC from happening, thus we get automatic cache invalidation.

Another way of thinking about it is that this new implementation is just intercepting a function `foo(x) => y` and looking into the current memory space, if it finds `x` lying around there, it will return `y` immediately instead of executing code in `foo`. Since JS anyway keeps `x` lying around for some time before the GC happens, this is quite efficient.

The outputs below are running `console.log(process.memoryUsage())`.

### Memory usage before

`heapUsed` grows about +23MB every page, and seems to be garbage collected every 2 pages or so.

```
page #0
operations=>bitset: 1.198ms
bitset=>sort=>msgs: 372.497ms
{ rss: 101519360,
  heapTotal: 60473344,
  heapUsed: 26870080,
  external: 21645308 }
page #1
operations=>bitset: 0.033ms
bitset=>sort=>msgs: 237.332ms
{ rss: 129568768,
  heapTotal: 76136448,
  heapUsed: 52908064,
  external: 21702652 }
page #2
operations=>bitset: 0.012ms
bitset=>sort=>msgs: 175.311ms
{ rss: 146042880,
  heapTotal: 93372416,
  heapUsed: 59703264,
  external: 21702652 }
page #3
operations=>bitset: 0.011ms
bitset=>sort=>msgs: 238.289ms
{ rss: 128802816,
  heapTotal: 73809920,
  heapUsed: 42068888,
  external: 21768188 }
page #4
operations=>bitset: 0.010ms
bitset=>sort=>msgs: 174.047ms
{ rss: 145002496,
  heapTotal: 89473024,
  heapUsed: 64705336,
  external: 21768188 }
page #5
operations=>bitset: 0.010ms
bitset=>sort=>msgs: 244.777ms
{ rss: 129695744,
  heapTotal: 74334208,
  heapUsed: 42148560,
  external: 21768188 }
page #6
operations=>bitset: 0.014ms
bitset=>sort=>msgs: 176.887ms
{ rss: 145293312,
  heapTotal: 89473024,
  heapUsed: 64785984,
  external: 21833724 }
page #7
operations=>bitset: 0.010ms
bitset=>sort=>msgs: 175.568ms
{ rss: 161783808,
  heapTotal: 107757568,
  heapUsed: 70903304,
  external: 21899260 }
page #8
operations=>bitset: 0.012ms
bitset=>sort=>msgs: 230.401ms
{ rss: 129167360,
  heapTotal: 73809920,
  heapUsed: 41868592,
  external: 21964796 }
page #9
operations=>bitset: 0.010ms
bitset=>sort=>msgs: 176.950ms
{ rss: 145027072,
  heapTotal: 89473024,
  heapUsed: 64473936,
  external: 22030332 }
```

### Memory usage after

`heapUsed` remains roughly 22MB during the entire pagination process, only slightly increasing.

```
page #0
operations=>bitset: 1.264ms
bitset=>sort=>msgs: 373.647ms
{ rss: 100339712,
  heapTotal: 59949056,
  heapUsed: 22089040,
  external: 21645308 }
page #1
operations=>bitset: 0.064ms
bitset=>sort=>msgs: 0.383ms
{ rss: 100544512,
  heapTotal: 59949056,
  heapUsed: 22155144,
  external: 21710844 }
page #2
operations=>bitset: 0.006ms
bitset=>sort=>msgs: 0.069ms
{ rss: 100544512,
  heapTotal: 59949056,
  heapUsed: 22178792,
  external: 21710844 }
page #3
operations=>bitset: 0.003ms
bitset=>sort=>msgs: 0.252ms
{ rss: 100544512,
  heapTotal: 59949056,
  heapUsed: 22203440,
  external: 21776380 }
page #4
operations=>bitset: 0.003ms
bitset=>sort=>msgs: 0.056ms
{ rss: 100544512,
  heapTotal: 59949056,
  heapUsed: 22224368,
  external: 21776380 }
page #5
operations=>bitset: 0.003ms
bitset=>sort=>msgs: 0.063ms
{ rss: 100544512,
  heapTotal: 59949056,
  heapUsed: 22248488,
  external: 21776380 }
page #6
operations=>bitset: 0.003ms
bitset=>sort=>msgs: 0.150ms
{ rss: 100544512,
  heapTotal: 59949056,
  heapUsed: 22271448,
  external: 21841916 }
page #7
operations=>bitset: 0.004ms
bitset=>sort=>msgs: 0.229ms
{ rss: 100544512,
  heapTotal: 59949056,
  heapUsed: 22292952,
  external: 21907452 }
page #8
operations=>bitset: 0.005ms
bitset=>sort=>msgs: 0.551ms
{ rss: 100544512,
  heapTotal: 59949056,
  heapUsed: 22314720,
  external: 21972988 }
page #9
operations=>bitset: 0.005ms
bitset=>sort=>msgs: 0.167ms
{ rss: 100544512,
  heapTotal: 59949056,
  heapUsed: 22336064,
  external: 22038524 }
```
