### PR TITLE
split LIVEOFFSETS and OFFSETS

### DIFF
--- a/index.js
+++ b/index.js
@@ -601,9 +601,7 @@ module.exports = function (log, indexesPath) {
         cb(new TypedFastBitSet(op.offsets))
       })
     } else if (op.type === 'LIVEOFFSETS') {
-      ensureOffsetIndexSync(() => {
-        cb(new TypedFastBitSet(op.offsets))
-      })
+      cb(new TypedFastBitSet())
     } else if (op.type === 'AND') {
       if (op.data.length > 2) op = nestLargeOpsArray(op.data, 'AND')
 

--- a/operators.js
+++ b/operators.js
@@ -31,10 +31,9 @@ function offsets(values) {
   }
 }
 
-function liveOffsets(values, pullStream) {
+function liveOffsets(pullStream) {
   return {
     type: 'LIVEOFFSETS',
-    offsets: values,
     stream: pullStream,
   }
 }

--- a/test/live.js
+++ b/test/live.js
@@ -255,9 +255,17 @@ prepareAndRunTest('Live with offset values', dir, (t, db, raf) => {
         },
       },
       {
-        type: 'LIVEOFFSETS',
-        offsets: [0],
-        stream: ps,
+        type: 'OR',
+        data: [
+          {
+            type: 'OFFSETS',
+            offsets: [0],
+          },
+          {
+            type: 'LIVEOFFSETS',
+            stream: ps,
+          },
+        ],
       },
     ],
   }

--- a/test/operators.js
+++ b/test/operators.js
@@ -822,7 +822,7 @@ prepareAndRunTest('support live offset operations', dir, (t, db, raf) => {
     and(
       deferred((meta, cb) => {
         setTimeout(() => {
-          cb(null, liveOffsets([], ps))
+          cb(null, liveOffsets(ps))
         }, 100)
       })
     ),


### PR DESCRIPTION
For issue #41 

Basically they should be used with an OR now: `or(offsets([1,2,3], liveOffsets(ps))`. I can update ssb-db2 after this is merged.