### PR TITLE
add bitset.size() and version to index file header

### DIFF
--- a/files.js
+++ b/files.js
@@ -4,17 +4,38 @@ const TypedFastBitSet = require('typedfastbitset')
 const { readFile, writeFile } = require('atomically-universal')
 const toBuffer = require('typedarray-to-buffer')
 
-function saveTypedArrayFile(filename, seq, count, tarr, cb) {
+const FIELD_SIZE = 4 // bytes
+
+/*
+ * ## File format for tarr files
+ *
+ * Each header field is 4 bytes in size.
+ *
+ * | offset (bytes) | name    | type     |
+ * |----------------|---------|----------|
+ * | 0              | version | UInt32LE |
+ * | 4              | seq     | UInt32LE |
+ * | 8              | count   | UInt32LE |
+ * | 12             | (N/A)   | (N/A)    |
+ * | 16             | body    | Buffer   |
+ *
+ * Note that the 4th header field (offset=12) is empty on purpose, to support
+ * `new Float64Array(b,start,len)` where `start` must be a multiple of 8
+ * when loading in `loadTypedArrayFile`.
+ */
+
+function saveTypedArrayFile(filename, version, seq, count, tarr, cb) {
   if (!cb) cb = () => {}
 
   const dataBuffer = toBuffer(tarr)
   // we try to save an extra 10% so we don't have to immediately grow
   // after loading and adding again
   const saveSize = Math.min(count * 1.1, tarr.length)
-  const b = Buffer.alloc(8 + saveSize * tarr.BYTES_PER_ELEMENT)
-  b.writeInt32LE(seq, 0)
-  b.writeInt32LE(count, 4)
-  dataBuffer.copy(b, 8)
+  const b = Buffer.alloc(4 * FIELD_SIZE + saveSize * tarr.BYTES_PER_ELEMENT)
+  b.writeUInt32LE(version, 0)
+  b.writeUInt32LE(seq, FIELD_SIZE)
+  b.writeUInt32LE(count, 2 * FIELD_SIZE)
+  dataBuffer.copy(b, 4 * FIELD_SIZE)
 
   writeFile(filename, b)
     .then(() => cb())
@@ -24,11 +45,13 @@ function saveTypedArrayFile(filename, seq, count, tarr, cb) {
 function loadTypedArrayFile(filename, Type, cb) {
   readFile(filename)
     .then((buf) => {
-      const seq = buf.readInt32LE(0)
-      const count = buf.readInt32LE(4)
-      const body = buf.slice(8)
+      const version = buf.readUInt32LE(0)
+      const seq = buf.readUInt32LE(FIELD_SIZE)
+      const count = buf.readUInt32LE(2 * FIELD_SIZE)
+      const body = buf.slice(4 * FIELD_SIZE)
 
       cb(null, {
+        version,
         seq,
         count,
         tarr: new Type(
@@ -41,21 +64,25 @@ function loadTypedArrayFile(filename, Type, cb) {
     .catch(cb)
 }
 
-function saveBitsetFile(filename, seq, bitset, cb) {
+function saveBitsetFile(filename, version, seq, bitset, cb) {
   bitset.trim()
-  saveTypedArrayFile(filename, seq, bitset.count, bitset.words, cb)
+  saveTypedArrayFile(filename, seq, version, bitset.count, bitset.words, cb)
 }
 
 function loadBitsetFile(filename, cb) {
-  loadTypedArrayFile(filename, Uint32Array, (err, { tarr, count, seq }) => {
-    if (err) cb(err)
-    else {
-      const bitset = new TypedFastBitSet()
-      bitset.words = tarr
-      bitset.count = count
-      cb(null, { seq, bitset })
+  loadTypedArrayFile(
+    filename,
+    Uint32Array,
+    (err, { version, seq, count, tarr }) => {
+      if (err) cb(err)
+      else {
+        const bitset = new TypedFastBitSet()
+        bitset.words = tarr
+        bitset.count = count
+        cb(null, { version, seq, bitset })
+      }
     }
-  })
+  )
 }
 
 function listFilesIDB(dir, cb) {

--- a/files.js
+++ b/files.js
@@ -66,7 +66,7 @@ function loadTypedArrayFile(filename, Type, cb) {
 
 function saveBitsetFile(filename, version, seq, bitset, cb) {
   bitset.trim()
-  saveTypedArrayFile(filename, seq, version, bitset.count, bitset.words, cb)
+  saveTypedArrayFile(filename, version, seq, bitset.count, bitset.words, cb)
 }
 
 function loadBitsetFile(filename, cb) {

--- a/index.js
+++ b/index.js
@@ -147,6 +147,7 @@ module.exports = function (log, indexesPath) {
   }
 
   function saveCoreIndex(name, coreIndex, count) {
+    if (coreIndex.seq < 0) return
     debug('saving core index: %s', name)
     const filename = path.join(indexesPath, name + '.index')
     saveTypedArrayFile(
@@ -159,12 +160,14 @@ module.exports = function (log, indexesPath) {
   }
 
   function saveIndex(name, index, cb) {
+    if (index.seq < 0 || index.bitset.size() === 0) return
     debug('saving index: %s', name)
     const filename = path.join(indexesPath, name + '.index')
     saveBitsetFile(filename, index.version || 1, index.seq, index.bitset, cb)
   }
 
   function savePrefixIndex(name, prefixIndex, count, cb) {
+    if (prefixIndex.seq < 0) return
     debug('saving prefix index: %s', name)
     const num = prefixIndex.prefix
     const filename = path.join(indexesPath, name + `.${num}prefix`)

--- a/index.js
+++ b/index.js
@@ -149,20 +149,33 @@ module.exports = function (log, indexesPath) {
   function saveCoreIndex(name, coreIndex, count) {
     debug('saving core index: %s', name)
     const filename = path.join(indexesPath, name + '.index')
-    saveTypedArrayFile(filename, coreIndex.seq, count, coreIndex.tarr)
+    saveTypedArrayFile(
+      filename,
+      coreIndex.version || 1,
+      coreIndex.seq,
+      count,
+      coreIndex.tarr
+    )
   }
 
   function saveIndex(name, index, cb) {
     debug('saving index: %s', name)
     const filename = path.join(indexesPath, name + '.index')
-    saveBitsetFile(filename, index.seq, index.bitset, cb)
+    saveBitsetFile(filename, index.version || 1, index.seq, index.bitset, cb)
   }
 
   function savePrefixIndex(name, prefixIndex, count, cb) {
     debug('saving prefix index: %s', name)
     const num = prefixIndex.prefix
     const filename = path.join(indexesPath, name + `.${num}prefix`)
-    saveTypedArrayFile(filename, prefixIndex.seq, count, prefixIndex.tarr, cb)
+    saveTypedArrayFile(
+      filename,
+      prefixIndex.version || 1,
+      prefixIndex.seq,
+      count,
+      prefixIndex.tarr,
+      cb
+    )
   }
 
   function growTarrIndex(index, Type) {
@@ -460,18 +473,20 @@ module.exports = function (log, indexesPath) {
       loadTypedArrayFile(
         index.filepath,
         Uint32Array,
-        (err, { seq, tarr, count }) => {
+        (err, { version, seq, count, tarr }) => {
           // FIXME: handle error
+          index.version = version
           index.seq = seq
-          index.tarr = tarr
           index.count = count
+          index.tarr = tarr
           index.lazy = false
           cb()
         }
       )
     } else {
-      loadBitsetFile(index.filepath, (err, { seq, bitset }) => {
+      loadBitsetFile(index.filepath, (err, { version, seq, bitset }) => {
         // FIXME: handle error
+        index.version = version
         index.seq = seq
         index.bitset = bitset
         index.lazy = false

--- a/test/save-load.js
+++ b/test/save-load.js
@@ -25,12 +25,14 @@ test('save and load bitsets', (t) => {
   saveBitsetFile(filename, 1, 123, bitset, (err) => {
     loadBitsetFile(filename, (err, index) => {
       t.error(err, 'no error')
+      t.equal(index.version, 1)
       let loadedBitset = index.bitset
       t.deepEqual(bitset.array(), loadedBitset.array())
       loadedBitset.add(10)
 
       saveBitsetFile(filename, 1, 1234, loadedBitset, (err) => {
         loadBitsetFile(filename, (err, index) => {
+          t.equal(index.version, 1)
           t.error(err, 'no error')
           let loadedBitset2 = index.bitset
           t.deepEqual(loadedBitset.array(), loadedBitset2.array())

--- a/test/save-load.js
+++ b/test/save-load.js
@@ -22,14 +22,14 @@ test('save and load bitsets', (t) => {
   var bitset = new TypedFastBitSet()
   for (var i = 0; i < 10; i += 2) bitset.add(i)
 
-  saveBitsetFile(filename, 123, bitset, (err) => {
+  saveBitsetFile(filename, 1, 123, bitset, (err) => {
     loadBitsetFile(filename, (err, index) => {
       t.error(err, 'no error')
       let loadedBitset = index.bitset
       t.deepEqual(bitset.array(), loadedBitset.array())
       loadedBitset.add(10)
 
-      saveBitsetFile(filename, 1234, loadedBitset, (err) => {
+      saveBitsetFile(filename, 1, 1234, loadedBitset, (err) => {
         loadBitsetFile(filename, (err, index) => {
           t.error(err, 'no error')
           let loadedBitset2 = index.bitset
@@ -49,7 +49,7 @@ test('save and load TypedArray for offset', (t) => {
   var tarr = new Uint32Array(16 * 1000)
   for (var i = 0; i < 10; i += 1) tarr[i] = i
 
-  saveTypedArrayFile(filename, 123, 10, tarr, (err) => {
+  saveTypedArrayFile(filename, 1, 123, 10, tarr, (err) => {
     loadTypedArrayFile(filename, Uint32Array, (err, loadedIdx) => {
       t.equal(loadedIdx.tarr.length, 10 * 1.1, 'file trimmed')
 
@@ -57,7 +57,7 @@ test('save and load TypedArray for offset', (t) => {
 
       loadedIdx.tarr[10] = 10
 
-      saveTypedArrayFile(filename, 1234, 11, loadedIdx.tarr, (err) => {
+      saveTypedArrayFile(filename, 1, 1234, 11, loadedIdx.tarr, (err) => {
         loadTypedArrayFile(filename, Uint32Array, (err, loadedIdx2) => {
           for (var i = 0; i < 11; i += 1)
             t.equal(loadedIdx.tarr[i], loadedIdx2.tarr[i])
@@ -76,13 +76,14 @@ test('save and load TypedArray for timestamp', (t) => {
   var tarr = new Float64Array(16 * 1000)
   for (var i = 0; i < 10; i += 1) tarr[i] = i * 1000000
 
-  saveTypedArrayFile(filename, 123, 10, tarr, (err) => {
+  saveTypedArrayFile(filename, 1, 123, 10, tarr, (err) => {
     loadTypedArrayFile(filename, Float64Array, (err, loadedIdx) => {
+      t.error(err, 'no error')
       for (var i = 0; i < 10; i += 1) t.equal(tarr[i], loadedIdx.tarr[i])
 
       loadedIdx.tarr[10] = 10 * 1000000
 
-      saveTypedArrayFile(filename, 1234, 11, loadedIdx.tarr, (err) => {
+      saveTypedArrayFile(filename, 1, 1234, 11, loadedIdx.tarr, (err) => {
         loadTypedArrayFile(filename, Float64Array, (err, loadedIdx2) => {
           for (var i = 0; i < 11; i += 1)
             t.equal(loadedIdx.tarr[i], loadedIdx2.tarr[i])


### PR DESCRIPTION
For issues #8 and #65, this adds two new fields to the file header: `version` and `bitsetSize`. Note it's a breaking change for any system currently deploying jitdb indexes.

So far there is no `bitset.size()` optimization (that old idea of not storing indexes that are too small), but if we ever want to implement that idea, this new header would make it easier.