### PR TITLE
Better support for delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,11 +364,12 @@ _Rule of thumb_: use prefix indexes in an EQUAL operation only when the target `
 
 ## Low-level API
 
-### paginate(operation, offset, limit, descending, cb)
+### paginate(operation, offset, limit, descending, onlySeq, cb)
 
 Query the database returning paginated results. If one or more indexes
 doesn't exist or are outdated, the indexes will be updated before the
-query is run. The result is an object with the fields:
+query is run. `onlySeq` be be used to return seqs instead of the
+actual messages. The result is an object with the fields:
 
 - `data`: the actual messages
 - `total`: the total number of messages
@@ -385,14 +386,28 @@ Operation can be of the following types:
 | AND           | [operation, operation]                       |
 | OR            | [operation, operation]                       |
 
-`seek` is a function that takes a buffer from the database as input and returns an index in the buffer from where a value can be compared to the `value` given. If value is `undefined` it corresponds to the field not being defined at that point in the buffer. `prefix` enables the use of prefix indexes for this operation. `indexType` is used to group indexes of the same type. If `indexAll` is specified and no index of the type and value exists, then instead of only this index being created, missing indexes for all possible values given the seek pointer will be created. This can be particular useful for data where there number of different values are rather small, but still larger than a few. One example is author or feeds in SSB, a typical database of 1 million records will have roughly 700 authors. The biggest cost in creating the indexes is traversing the database, so creating all indexes in one go instead of several hundreds is a lot faster.
+`seek` is a function that takes a buffer from the database as input
+and returns an index in the buffer from where a value can be compared
+to the `value` given. If value is `undefined` it corresponds to the
+field not being defined at that point in the buffer. `prefix` enables
+the use of prefix indexes for this operation. `indexType` is used to
+group indexes of the same type. If `indexAll` is specified and no
+index of the type and value exists, then instead of only this index
+being created, missing indexes for all possible values given the seek
+pointer will be created. This can be particular useful for data where
+there number of different values are rather small, but still larger
+than a few. One example is author or feeds in SSB, a typical database
+of 1 million records will have roughly 700 authors. The biggest cost
+in creating the indexes is traversing the database, so creating all
+indexes in one go instead of several hundreds is a lot faster.
 
 For `GT`, `GTE`, `LT` and `LTE`, `indexName` can be either `sequence`
 or `timestamp`.
 
-`OFFSETS` and `SEQS` allow one to use offset and seq (respectively) positions
-into the log file as query operators. This is useful for interfacing with data indexed by something else than JITDB. Offsets are faster as they can be combined
-in queries directly.
+`OFFSETS` and `SEQS` allow one to use offset and seq (respectively)
+positions into the log file as query operators. This is useful for
+interfacing with data indexed by something else than JITDB. Offsets
+are faster as they can be combined in queries directly.
 
 Example
 
@@ -411,7 +426,7 @@ some after processing that you wouldn't create and index for, but the
 overhead of decoding the buffers is small enough that I don't think it
 makes sense.
 
-### all(operation, offset, descending, cb)
+### all(operation, offset, descending, onlySeq, cb)
 
 Similar to paginate except there is no `limit` argument and the result
 will be the messages directly.

--- a/index.js
+++ b/index.js
@@ -396,7 +396,7 @@ module.exports = function (log, indexesPath) {
         }
     })
 
-    let offset = -1
+    let offset = 0
 
     let updatedOffsetIndex = false
     let updatedTimestampIndex = false
@@ -406,14 +406,16 @@ module.exports = function (log, indexesPath) {
     log.stream({}).pipe({
       paused: false,
       write: function (record) {
-        offset++
-
         const seq = record.seq
         const buffer = record.value
 
         if (updateOffsetIndex(offset, seq)) updatedOffsetIndex = true
 
-        if (!buffer) return // deleted
+        if (!buffer) {
+          // deleted
+          offset++
+          return
+        }
 
         if (updateTimestampIndex(offset, seq, buffer))
           updatedTimestampIndex = true
@@ -435,6 +437,8 @@ module.exports = function (log, indexesPath) {
           else
             updateIndexValue(op, newIndexes[op.data.indexName], buffer, offset)
         })
+
+        offset++
       },
       end: () => {
         const count = offset // incremented at end

--- a/operators.js
+++ b/operators.js
@@ -337,8 +337,15 @@ function toCallback(cb) {
       .then((ops) => {
         const offset = meta.offset || 0
         if (meta.pageSize)
-          meta.db.paginate(ops, offset, meta.pageSize, meta.descending, cb)
-        else meta.db.all(ops, offset, meta.descending, cb)
+          meta.db.paginate(
+            ops,
+            offset,
+            meta.pageSize,
+            meta.descending,
+            false,
+            cb
+          )
+        else meta.db.all(ops, offset, meta.descending, false, cb)
       })
       .catch((err) => {
         cb(err)
@@ -363,15 +370,22 @@ function toPullStream() {
       return function readable(end, cb) {
         if (end) return cb(end)
         if (offset >= total) return cb(true)
-        meta.db.paginate(ops, offset, limit, meta.descending, (err, answer) => {
-          if (err) return cb(err)
-          else if (answer.total === 0) cb(true)
-          else {
-            total = answer.total
-            offset += limit
-            cb(null, !meta.pageSize ? answer.results[0] : answer.results)
+        meta.db.paginate(
+          ops,
+          offset,
+          limit,
+          meta.descending,
+          false,
+          (err, answer) => {
+            if (err) return cb(err)
+            else if (answer.total === 0) cb(true)
+            else {
+              total = answer.total
+              offset += limit
+              cb(null, !meta.pageSize ? answer.results[0] : answer.results)
+            }
           }
-        })
+        )
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "typedfastbitset": "^0.1.5"
   },
   "devDependencies": {
-    "async-flumelog": "^1.0.11",
+    "async-flumelog": "^2.0.0",
     "flumecodec": "0.0.1",
     "flumelog-offset": "3.4.4",
     "husky": "^4.3.0",

--- a/test/del.js
+++ b/test/del.js
@@ -35,10 +35,10 @@ prepareAndRunTest('Delete', dir, (t, db, raf) => {
     addMsg(state.queue[1].value, raf, (err, msg2, seq2) => {
       addMsg(state.queue[2].value, raf, (err, msg3) => {
         raf.del(seq2, () => {
-          db.paginate(typeQuery, 0, 10, false, (err, { results }) => {
+          db.paginate(typeQuery, 0, 10, false, false, (err, { results }) => {
             t.deepEqual(results, [msg1, msg3])
 
-            db.all(typeQuery, 0, false, (err, results) => {
+            db.all(typeQuery, 0, false, false, (err, results) => {
               t.deepEqual(results, [msg1, msg3])
               t.end()
             })

--- a/test/live.js
+++ b/test/live.js
@@ -197,7 +197,7 @@ prepareAndRunTest('Live with initial values', dir, (t, db, raf) => {
 
   addMsg(state.queue[0].value, raf, (err, msg1) => {
     // create index
-    db.all(typeQuery, 0, false, (err, results) => {
+    db.all(typeQuery, 0, false, false, (err, results) => {
       t.equal(results.length, 1)
 
       pull(
@@ -206,7 +206,7 @@ prepareAndRunTest('Live with initial values', dir, (t, db, raf) => {
           t.equal(result.key, state.queue[1].key)
 
           // rerun on updated index
-          db.all(typeQuery, 0, false, (err, results) => {
+          db.all(typeQuery, 0, false, false, (err, results) => {
             t.equal(results.length, 2)
             t.end()
           })
@@ -271,7 +271,7 @@ prepareAndRunTest('Live with offset values', dir, (t, db, raf) => {
   }
 
   addMsg(state.queue[0].value, raf, (err, msg1) => {
-    db.all(typeQuery, 0, false, (err, results) => {
+    db.all(typeQuery, 0, false, false, (err, results) => {
       t.equal(results.length, 1)
 
       let liveI = 1

--- a/test/prefix.js
+++ b/test/prefix.js
@@ -34,7 +34,7 @@ prepareAndRunTest('Prefix equal', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(typeQuery, 0, false, (err, results) => {
+        db.all(typeQuery, 0, false, false, (err, results) => {
           t.equal(results.length, 2)
           t.equal(results[0].value.content.type, 'post')
           t.equal(results[1].value.content.type, 'post')
@@ -68,7 +68,7 @@ prepareAndRunTest('Prefix larger than actual value', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(typeQuery, 0, false, (err, results) => {
+        db.all(typeQuery, 0, false, false, (err, results) => {
           t.equal(results.length, 1)
           t.equal(results[0].value.content.text, 'First')
           t.end()
@@ -101,7 +101,7 @@ prepareAndRunTest('Prefix equal falsy', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(typeQuery, 0, false, (err, results) => {
+        db.all(typeQuery, 0, false, false, (err, results) => {
           t.equal(results.length, 2)
           t.equal(results[0].value.content.text, 'Second')
           t.equal(results[1].value.content.text, 'Third')

--- a/test/query.js
+++ b/test/query.js
@@ -46,12 +46,12 @@ prepareAndRunTest('Multiple types', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(typeQuery, 0, false, (err, results) => {
+        db.all(typeQuery, 0, false, false, (err, results) => {
           t.equal(results.length, 2)
           t.equal(results[0].value.content.type, 'post')
           t.equal(results[1].value.content.type, 'post')
 
-          db.all(contactQuery, 0, false, (err, results) => {
+          db.all(contactQuery, 0, false, false, (err, results) => {
             t.equal(results.length, 1)
             t.equal(results[0].value.content.type, 'contact')
 
@@ -86,7 +86,7 @@ prepareAndRunTest('Top 1 multiple types', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.paginate(typeQuery, 0, 1, true, (err, { results }) => {
+        db.paginate(typeQuery, 0, 1, true, false, (err, { results }) => {
           t.equal(results.length, 1)
           t.equal(results[0].value.content.text, 'Testing 2!')
           t.end()
@@ -119,7 +119,7 @@ prepareAndRunTest('Includes', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err1, msg) => {
     addMsg(state.queue[1].value, raf, (err2, msg) => {
       addMsg(state.queue[2].value, raf, (err3, msg) => {
-        db.all(typeQuery, 0, false, (err4, results) => {
+        db.all(typeQuery, 0, false, false, (err4, results) => {
           t.error(err4)
           t.equal(results.length, 2)
           t.equal(results[0].value.content.text, '1st')
@@ -167,7 +167,7 @@ prepareAndRunTest('Includes and pluck', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err1, msg) => {
     addMsg(state.queue[1].value, raf, (err2, msg) => {
       addMsg(state.queue[2].value, raf, (err3, msg) => {
-        db.all(typeQuery, 0, false, (err4, results) => {
+        db.all(typeQuery, 0, false, false, (err4, results) => {
           t.error(err4)
           t.equal(results.length, 2)
           t.equal(results[0].value.content.text, '1st')
@@ -202,13 +202,13 @@ prepareAndRunTest('Paginate many pages', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.paginate(typeQuery, 0, 1, false, (err, { results }) => {
+        db.paginate(typeQuery, 0, 1, false, false, (err, { results }) => {
           t.equal(results.length, 1)
           t.equal(results[0].value.content.text, '1st')
-          db.paginate(typeQuery, 1, 1, false, (err, { results }) => {
+          db.paginate(typeQuery, 1, 1, false, false, (err, { results }) => {
             t.equal(results.length, 1)
             t.equal(results[0].value.content.text, '2nd')
-            db.paginate(typeQuery, 2, 1, false, (err, { results }) => {
+            db.paginate(typeQuery, 2, 1, false, false, (err, { results }) => {
               t.equal(results.length, 1)
               t.equal(results[0].value.content.text, '3rd')
               t.end()
@@ -243,7 +243,7 @@ prepareAndRunTest('Offset', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.paginate(typeQuery, 1, 1, true, (err, { results }) => {
+        db.paginate(typeQuery, 1, 1, true, false, (err, { results }) => {
           t.equal(results.length, 1)
           t.equal(results[0].value.content.text, 'Testing!')
           t.end()
@@ -270,7 +270,7 @@ prepareAndRunTest('Buffer', dir, (t, db, raf) => {
   }
 
   addMsg(state.queue[0].value, raf, (err, msg) => {
-    db.paginate(typeQuery, 0, 1, true, (err, { results }) => {
+    db.paginate(typeQuery, 0, 1, true, false, (err, { results }) => {
       t.equal(results.length, 1)
       t.equal(results[0].value.content.text, 'Testing!')
       t.end()
@@ -298,7 +298,7 @@ prepareAndRunTest('Undefined', dir, (t, db, raf) => {
 
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
-      db.paginate(typeQuery, 0, 1, true, (err, { results }) => {
+      db.paginate(typeQuery, 0, 1, true, false, (err, { results }) => {
         t.equal(results.length, 1)
         t.equal(results[0].value.content.text, 'Testing no root')
         t.end()
@@ -327,7 +327,7 @@ prepareAndRunTest('Null', dir, (t, db, raf) => {
 
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
-      db.paginate(typeQuery, 0, 1, true, (err, { results }) => {
+      db.paginate(typeQuery, 0, 1, true, false, (err, { results }) => {
         t.equal(results.length, 1)
         t.equal(results[0].value.content.text, 'Testing no root')
         t.end()
@@ -375,7 +375,7 @@ prepareAndRunTest('GT,GTE,LT,LTE', dir, (t, db, raf) => {
     addMsg(state.queue[1].value, raf, (err, dbMsg2) => {
       addMsg(state.queue[2].value, raf, (err, dbMsg3) => {
         addMsg(state.queue[3].value, raf, (err, dbMsg4) => {
-          db.all(filterQuery, 0, false, (err, results) => {
+          db.all(filterQuery, 0, false, false, (err, results) => {
             t.error(err, 'no err')
             t.equal(results.length, 3)
             t.equal(results[0].value.content.text, '2')
@@ -383,7 +383,7 @@ prepareAndRunTest('GT,GTE,LT,LTE', dir, (t, db, raf) => {
             filterQuery.data[0].type = 'GTE'
             // clone to force cache invalidation inside db.all:
             filterQuery = Object.assign({}, filterQuery)
-            db.all(filterQuery, 0, false, (err, results) => {
+            db.all(filterQuery, 0, false, false, (err, results) => {
               t.equal(results.length, 4)
               t.equal(results[0].value.content.text, '1')
 
@@ -391,14 +391,14 @@ prepareAndRunTest('GT,GTE,LT,LTE', dir, (t, db, raf) => {
               filterQuery.data[0].data.value = 3
               // clone to force cache invalidation inside db.all:
               filterQuery = Object.assign({}, filterQuery)
-              db.all(filterQuery, 0, false, (err, results) => {
+              db.all(filterQuery, 0, false, false, (err, results) => {
                 t.equal(results.length, 2)
                 t.equal(results[0].value.content.text, '1')
 
                 filterQuery.data[0].type = 'LTE'
                 // clone to force cache invalidation inside db.all:
                 filterQuery = Object.assign({}, filterQuery)
-                db.all(filterQuery, 0, false, (err, results) => {
+                db.all(filterQuery, 0, false, false, (err, results) => {
                   t.equal(results.length, 3)
                   t.equal(results[0].value.content.text, '1')
 
@@ -407,7 +407,7 @@ prepareAndRunTest('GT,GTE,LT,LTE', dir, (t, db, raf) => {
                   filterQuery.data[0].data.value = dbMsg1.value.timestamp
                   // clone to force cache invalidation inside db.all:
                   filterQuery = Object.assign({}, filterQuery)
-                  db.all(filterQuery, 0, false, (err, results) => {
+                  db.all(filterQuery, 0, false, false, (err, results) => {
                     t.equal(results.length, 3)
                     t.equal(results[0].value.content.text, '2')
 
@@ -447,7 +447,7 @@ prepareAndRunTest('GTE Zero', dir, (t, db, raf) => {
     addMsg(state.queue[1].value, raf, (err, dbMsg2) => {
       addMsg(state.queue[2].value, raf, (err, dbMsg3) => {
         addMsg(state.queue[3].value, raf, (err, dbMsg4) => {
-          db.all(filterQuery, 0, false, (err, results) => {
+          db.all(filterQuery, 0, false, false, (err, results) => {
             t.equal(results.length, 4)
             t.equal(results[0].value.content.text, '1')
             t.equal(results[1].value.content.text, '2')
@@ -493,7 +493,7 @@ prepareAndRunTest('Data seqs', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.paginate(dataQuery, 0, 1, true, (err, { results }) => {
+        db.paginate(dataQuery, 0, 1, true, false, (err, { results }) => {
           t.equal(results.length, 1)
           t.equal(results[0].value.content.text, 'Testing no root')
           t.end()
@@ -521,7 +521,7 @@ prepareAndRunTest('Data offsets simple', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(dataQuery, 0, false, (err, results) => {
+        db.all(dataQuery, 0, false, false, (err, results) => {
           t.equal(results.length, 2)
           t.equal(results[0].value.content.name, 'Test')
           t.equal(results[1].value.content.text, 'Testing no root')
@@ -564,7 +564,7 @@ prepareAndRunTest('Data offsets', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.paginate(dataQuery, 0, 1, true, (err, { results }) => {
+        db.paginate(dataQuery, 0, 1, true, false, (err, { results }) => {
           t.equal(results.length, 1)
           t.equal(results[0].value.content.text, 'Testing no root')
           t.end()
@@ -620,7 +620,7 @@ prepareAndRunTest('Multiple ands', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(allQuery, 0, false, (err, results) => {
+        db.all(allQuery, 0, false, false, (err, results) => {
           t.equal(results.length, 1)
           t.equal(results[0].value.content.text, 'Testing 2!')
           t.end()
@@ -693,7 +693,7 @@ prepareAndRunTest('Multiple ors', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(allQuery, 0, false, (err, results) => {
+        db.all(allQuery, 0, false, false, (err, results) => {
           t.equal(results.length, 2)
           t.equal(results[0].value.content.text, 'Testing!')
           t.equal(results[1].value.content.text, 'Testing 2!')
@@ -727,7 +727,7 @@ prepareAndRunTest('Timestamp discontinuity', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, m1) => {
     addMsg(state.queue[1].value, raf, (err, m2) => {
       addMsg(state.queue[2].value, raf, (err, m3) => {
-        db.all(authorQuery, 0, false, (err, results) => {
+        db.all(authorQuery, 0, false, false, (err, results) => {
           t.equal(results.length, 3)
           t.equal(results[0].value.content.text, '1st', '1st ok')
           t.equal(results[1].value.content.text, '2nd', '2nd ok')


### PR DESCRIPTION
For delete in ssb-db2 we need a way to get the seq of specific messages so we can call delete on the log with the seq. While testing this in ssb-db2 I found some other bugs, one in matchprefix and one related to https://github.com/flumedb/async-flumelog/pull/13. Because of this the PR is bigger than I would have liked. I didn't add an operator for this because the query is simple enough to just write using the raw api and can always be added later if needed.