### PR TITLE
Fix error handling when loading files

### DIFF
--- a/files.js
+++ b/files.js
@@ -70,19 +70,16 @@ function saveBitsetFile(filename, version, offset, bitset, cb) {
 }
 
 function loadBitsetFile(filename, cb) {
-  loadTypedArrayFile(
-    filename,
-    Uint32Array,
-    (err, { version, offset, count, tarr }) => {
-      if (err) cb(err)
-      else {
-        const bitset = new TypedFastBitSet()
-        bitset.words = tarr
-        bitset.count = count
-        cb(null, { version, offset, bitset })
-      }
+  loadTypedArrayFile(filename, Uint32Array, (err, data) => {
+    if (err) cb(err)
+    else {
+      const { version, offset, count, tarr } = data
+      const bitset = new TypedFastBitSet()
+      bitset.words = tarr
+      bitset.count = count
+      cb(null, { version, offset, bitset })
     }
-  )
+  })
 }
 
 function listFilesIDB(dir, cb) {

--- a/index.js
+++ b/index.js
@@ -485,19 +485,16 @@ module.exports = function (log, indexesPath) {
     debug('lazy loading %s', indexName)
     let index = indexes[indexName]
     if (index.prefix) {
-      loadTypedArrayFile(
-        index.filepath,
-        Uint32Array,
-        (err, { version, offset, count, tarr }) => {
-          // FIXME: handle error
-          index.version = version
-          index.offset = offset
-          index.count = count
-          index.tarr = tarr
-          index.lazy = false
-          cb()
-        }
-      )
+      loadTypedArrayFile(index.filepath, Uint32Array, (err, data) => {
+        if (err) return cb(err)
+        const { version, offset, count, tarr } = data
+        index.version = version
+        index.offset = offset
+        index.count = count
+        index.tarr = tarr
+        index.lazy = false
+        cb()
+      })
     } else {
       loadBitsetFile(index.filepath, (err, { version, offset, bitset }) => {
         // FIXME: handle error

--- a/index.js
+++ b/index.js
@@ -496,8 +496,9 @@ module.exports = function (log, indexesPath) {
         cb()
       })
     } else {
-      loadBitsetFile(index.filepath, (err, { version, offset, bitset }) => {
-        // FIXME: handle error
+      loadBitsetFile(index.filepath, (err, data) => {
+        if (err) return cb(err)
+        const { version, offset, bitset } = data
         index.version = version
         index.offset = offset
         index.bitset = bitset

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "pull-awaitable": "^1.0.0",
     "pull-cat": "~1.1.11",
     "pull-stream": "^3.6.14",
-    "push-stream-to-pull-stream": "^1.0.3",
     "push-stream": "^11.0.0",
+    "push-stream-to-pull-stream": "^1.0.3",
     "sanitize-filename": "^1.6.3",
     "traverse": "^0.6.6",
-    "typedarray-to-buffer": "^3.1.5",
+    "typedarray-to-buffer": "^4.0.0",
     "typedfastbitset": "^0.1.5"
   },
   "devDependencies": {

--- a/test/save-load.js
+++ b/test/save-load.js
@@ -95,3 +95,12 @@ test('save and load TypedArray for timestamp', (t) => {
     })
   })
 })
+
+test('load non-existing file', (t) => {
+  const filename = path.join('/IDontExist', 'test.index')
+
+  loadBitsetFile(filename, (err, index) => {
+    t.equal(err.code, 'ENOENT')
+    t.end()
+  })
+})


### PR DESCRIPTION
Still trying to make things work in the browser. I'm running into all kinds of nice error cases here ;-)

If file loading errors, don't try to destructure.

I also sneaked in a updated toBuffer as that is the version we are using in ssb-db2. It's mostly dropping IE support, which we don't need anyway in the browser. Shouldn't have any diff in node.