### PR TITLE
lock dependency TypedFastBitSet to 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "sanitize-filename": "^1.6.3",
     "traverse": "^0.6.6",
     "typedarray-to-buffer": "^4.0.0",
-    "typedfastbitset": "^0.1.5"
+    "typedfastbitset": "~0.1.5"
   },
   "devDependencies": {
     "async-append-only-log": "^3.0.2",


### PR DESCRIPTION
I tried to update this to 0.2.0 but it didn't pass tests. 0.2.0 has some new APIs that could help us, and I was curious would it make it faster. But I think we should consider 0.2.0 buggy, because it removes the `.count` property, which we need. Further, their codebase still has `.count` in some places and I think it's wrong (would be undefined), so I want to make sure we don't install 0.2.0 until those issues are fixed.