### PR TITLE
support and(live()) operations 

### DIFF
--- a/operators.js
+++ b/operators.js
@@ -251,12 +251,12 @@ function extractMeta(orig) {
 }
 
 function and(...args) {
-  const rhs = args
-    .map((arg) => (typeof arg === 'function' ? arg() : arg))
-    .filter((arg) => !!arg)
-  return (ops) => {
+  return (ops, isSpecialOps) => {
+    const rhs = args
+      .map((arg) => (typeof arg === 'function' ? arg(ops, true) : arg))
+      .filter((arg) => !!arg)
     const res =
-      ops && ops.type
+      ops && ops.type && !isSpecialOps
         ? {
             type: 'AND',
             data: [ops, ...rhs],
@@ -273,12 +273,12 @@ function and(...args) {
 }
 
 function or(...args) {
-  const rhs = args
-    .map((arg) => (typeof arg === 'function' ? arg() : arg))
-    .filter((arg) => !!arg)
-  return (ops) => {
+  return (ops, isSpecialOps) => {
+    const rhs = args
+      .map((arg) => (typeof arg === 'function' ? arg(ops, true) : arg))
+      .filter((arg) => !!arg)
     const res =
-      ops && ops.type
+      ops && ops.type && !isSpecialOps
         ? {
             type: 'OR',
             data: [ops, ...rhs],
@@ -293,6 +293,8 @@ function or(...args) {
     return res
   }
 }
+
+// The following are "special operators": they only update meta
 
 function live(opts) {
   if (opts && opts.old) return (ops) => updateMeta(ops, 'live', 'liveAndOld')


### PR DESCRIPTION
This is the bulk of the work to fix https://github.com/ssb-ngi-pointer/ssb-db2/issues/133

Note that the 2nd commit is a refactor that just shuffles around stuff. It's probably easiest to just review the 1st commit: https://github.com/ssb-ngi-pointer/jitdb/commit/97e7bb3de27c4c3f077010d6621efbefbb4b2ff4

About the refactor commit, `//#region` is a thing that VSCode interprets and allows you to collapse/expand. For non-VSCode users, this may still be readable comments. For VSCode users (many are), it might be helpful to collapse/expand.

![Screenshot from 2021-01-21 15-50-18](https://user-images.githubusercontent.com/90512/105359868-9a18bd00-5c00-11eb-9db7-fd3fb02547a0.png)
