### PR TITLE
Optimize prefixes for queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,12 @@ _Rule of thumb_: use prefix indexes in an EQUAL operation only when
 the target `value` of your EQUAL can dynamically assume many (more
 than a dozen) possible values.
 
+An additional option `useMap` can be provided that will store the
+prefix as a map instead of an array. The map can be seen as an
+inverted index that allows for faster queries at the cost of extra
+space. Maps don't store empty values meaning they are also a good fit
+for sparce indexes such as vote links.
+
 ## Low-level API
 
 First some terminology: offset refers to the byte position in the log

--- a/index.js
+++ b/index.js
@@ -326,8 +326,6 @@ module.exports = function (log, indexesPath) {
       if (fieldStart) {
         const buf = bipf.slice(buffer, fieldStart)
         addToPrefixMap(index.map, seq, buf.length ? safeReadUint32(buf) : 0)
-      } else {
-        addToPrefixMap(index.map, seq, 0)
       }
 
       index.offset = offset

--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ const debug = require('debug')('jitdb')
 const {
   saveTypedArrayFile,
   loadTypedArrayFile,
+  savePrefixMapFile,
+  loadPrefixMapFile,
   saveBitsetFile,
   loadBitsetFile,
   safeFilename,
@@ -113,6 +115,17 @@ module.exports = function (log, indexesPath) {
               filepath: path.join(indexesPath, file),
             }
             cb()
+          } else if (file.endsWith('.32prefixmap')) {
+            // Don't load it yet, just tag it `lazy`
+            indexes[indexName] = {
+              offset: -1,
+              count: 0,
+              map: {},
+              lazy: true,
+              prefix: 32,
+              filepath: path.join(indexesPath, file),
+            }
+            cb()
           } else if (file.endsWith('.index')) {
             // Don't load it yet, just tag it `lazy`
             indexes[indexName] = {
@@ -177,6 +190,21 @@ module.exports = function (log, indexesPath) {
       prefixIndex.offset,
       count,
       prefixIndex.tarr,
+      cb
+    )
+  }
+
+  function savePrefixMapIndex(name, prefixIndex, count, cb) {
+    if (prefixIndex.offset < 0) return
+    debug('saving prefix map index: %s', name)
+    const num = prefixIndex.prefix
+    const filename = path.join(indexesPath, name + `.${num}prefixmap`)
+    savePrefixMapFile(
+      filename,
+      prefixIndex.version || 1,
+      prefixIndex.offset,
+      count,
+      prefixIndex.map,
       cb
     )
   }
@@ -284,6 +312,29 @@ module.exports = function (log, indexesPath) {
     }
   }
 
+  function addToPrefixMap(map, seq, value) {
+    if (value === 0) return
+
+    let arr = map[value] || []
+    arr.push(seq)
+    map[value] = arr
+  }
+
+  function updatePrefixMapIndex(opData, index, buffer, seq, offset) {
+    if (seq > index.count - 1) {
+      const fieldStart = opData.seek(buffer)
+      if (fieldStart) {
+        const buf = bipf.slice(buffer, fieldStart)
+        addToPrefixMap(index.map, seq, buf.length ? safeReadUint32(buf) : 0)
+      } else {
+        addToPrefixMap(index.map, seq, 0)
+      }
+
+      index.offset = offset
+      index.count = seq + 1
+    }
+  }
+
   function updatePrefixIndex(opData, index, buffer, seq, offset) {
     if (seq > index.count - 1) {
       if (seq > index.tarr.length - 1) growTarrIndex(index, Uint32Array)
@@ -368,7 +419,9 @@ module.exports = function (log, indexesPath) {
           updatedSequenceIndex = true
 
         if (indexNeedsUpdate) {
-          if (op.data.prefix)
+          if (op.data.prefix && op.data.useMap)
+            updatePrefixMapIndex(op.data, index, buffer, seq, offset)
+          else if (op.data.prefix)
             updatePrefixIndex(op.data, index, buffer, seq, offset)
           else updateIndexValue(op, index, buffer, seq)
         }
@@ -389,7 +442,10 @@ module.exports = function (log, indexesPath) {
 
         index.offset = indexes['seq'].offset
         if (indexNeedsUpdate) {
-          if (index.prefix) savePrefixIndex(op.data.indexName, index, count)
+          if (index.prefix && index.map)
+            savePrefixMapIndex(op.data.indexName, index, count)
+          else if (index.prefix)
+            savePrefixIndex(op.data.indexName, index, count)
           else saveIndex(op.data.indexName, index)
         }
 
@@ -401,7 +457,14 @@ module.exports = function (log, indexesPath) {
   function createIndexes(opsMissingIndexes, cb) {
     const newIndexes = {}
     opsMissingIndexes.forEach((op) => {
-      if (op.data.prefix)
+      if (op.data.prefix && op.data.useMap) {
+        newIndexes[op.data.indexName] = {
+          offset: 0,
+          count: 0,
+          map: {},
+          prefix: typeof op.data.prefix === 'number' ? op.data.prefix : 32,
+        }
+      } else if (op.data.prefix)
         newIndexes[op.data.indexName] = {
           offset: 0,
           count: 0,
@@ -443,6 +506,14 @@ module.exports = function (log, indexesPath) {
           updatedSequenceIndex = true
 
         opsMissingIndexes.forEach((op) => {
+          if (op.data.prefix && op.data.useMap)
+            updatePrefixMapIndex(
+              op.data,
+              newIndexes[op.data.indexName],
+              buffer,
+              seq,
+              offset
+            )
           if (op.data.prefix)
             updatePrefixIndex(
               op.data,
@@ -473,7 +544,9 @@ module.exports = function (log, indexesPath) {
         for (var indexName in newIndexes) {
           const index = (indexes[indexName] = newIndexes[indexName])
           index.offset = indexes['seq'].offset
-          if (index.prefix) savePrefixIndex(indexName, index, count)
+          if (index.prefix && index.map)
+            savePrefixMapIndex(indexName, index, count)
+          else if (index.prefix) savePrefixIndex(indexName, index, count)
           else saveIndex(indexName, index)
         }
 
@@ -485,7 +558,18 @@ module.exports = function (log, indexesPath) {
   function loadLazyIndex(indexName, cb) {
     debug('lazy loading %s', indexName)
     let index = indexes[indexName]
-    if (index.prefix) {
+    if (index.prefix && index.map) {
+      loadPrefixMapFile(index.filepath, (err, data) => {
+        if (err) return cb(err)
+        const { version, offset, count, map } = data
+        index.version = version
+        index.offset = offset
+        index.count = count
+        index.map = map
+        index.lazy = false
+        cb()
+      })
+    } else if (index.prefix) {
       loadTypedArrayFile(index.filepath, Uint32Array, (err, data) => {
         if (err) return cb(err)
         const { version, offset, count, tarr } = data
@@ -576,16 +660,27 @@ module.exports = function (log, indexesPath) {
   function matchAgainstPrefix(op, prefixIndex, cb) {
     const target = op.data.value
     const targetPrefix = target ? safeReadUint32(target) : 0
-    const count = prefixIndex.count
-    const tarr = prefixIndex.tarr
     const bitset = new TypedFastBitSet()
     const done = multicb({ pluck: 1 })
-    for (let seq = 0; seq < count; ++seq) {
-      if (tarr[seq] === targetPrefix) {
-        bitset.add(seq)
-        getRecord(seq, done())
+
+    if (prefixIndex.map) {
+      if (prefixIndex.map[targetPrefix]) {
+        prefixIndex.map[targetPrefix].forEach((seq) => {
+          bitset.add(seq)
+          getRecord(seq, done())
+        })
+      }
+    } else {
+      const count = prefixIndex.count
+      const tarr = prefixIndex.tarr
+      for (let seq = 0; seq < count; ++seq) {
+        if (tarr[seq] === targetPrefix) {
+          bitset.add(seq)
+          getRecord(seq, done())
+        }
       }
     }
+
     done((err, recs) => {
       // FIXME: handle error better, this cb() should support 2 args
       if (err) return console.error(err)

--- a/index.js
+++ b/index.js
@@ -315,15 +315,14 @@ module.exports = function (log, indexesPath) {
   function addToPrefixMap(map, seq, value) {
     if (value === 0) return
 
-    let arr = map[value] || []
+    const arr = map[value] || (map[value] = [])
     arr.push(seq)
-    map[value] = arr
   }
 
   function updatePrefixMapIndex(opData, index, buffer, seq, offset) {
     if (seq > index.count - 1) {
       const fieldStart = opData.seek(buffer)
-      if (fieldStart) {
+      if (~fieldStart) {
         const buf = bipf.slice(buffer, fieldStart)
         addToPrefixMap(index.map, seq, buf.length ? safeReadUint32(buf) : 0)
       }
@@ -338,7 +337,7 @@ module.exports = function (log, indexesPath) {
       if (seq > index.tarr.length - 1) growTarrIndex(index, Uint32Array)
 
       const fieldStart = opData.seek(buffer)
-      if (fieldStart) {
+      if (~fieldStart) {
         const buf = bipf.slice(buffer, fieldStart)
         index.tarr[seq] = buf.length ? safeReadUint32(buf) : 0
       } else {

--- a/operators.js
+++ b/operators.js
@@ -78,15 +78,23 @@ function debug() {
 //#endregion
 //#region "Unit operators": they create objects that JITDB interprets
 
+function getIndexName(opts, indexType, valueName) {
+  return safeFilename(
+    opts.prefix
+      ? opts.useMap
+        ? indexType + '__map'
+        : indexType
+      : indexType + '_' + valueName
+  )
+}
+
 function slowEqual(seekDesc, target, opts) {
   opts = opts || {}
   const seek = seekFromDesc(seekDesc)
   const value = toBufferOrFalsy(target)
   const valueName = !value ? '' : value.toString()
   const indexType = seekDesc.replace(/\./g, '_')
-  const indexName = opts.prefix
-    ? safeFilename(indexType)
-    : safeFilename(indexType + '_' + valueName)
+  const indexName = getIndexName(opts, indexType, valueName)
   return {
     type: 'EQUAL',
     data: {
@@ -94,6 +102,7 @@ function slowEqual(seekDesc, target, opts) {
       value,
       indexType,
       indexName,
+      useMap: opts.useMap,
       indexAll: opts.indexAll,
       prefix: opts.prefix,
     },
@@ -107,13 +116,7 @@ function equal(seek, target, opts) {
   const value = toBufferOrFalsy(target)
   const valueName = !value ? '' : value.toString()
   const indexType = opts.indexType
-  const indexName = safeFilename(
-    opts.prefix
-      ? opts.useMap
-        ? indexType + '_map'
-        : indexType
-      : indexType + '_' + valueName
-  )
+  const indexName = getIndexName(opts, indexType, valueName)
   return {
     type: 'EQUAL',
     data: {

--- a/operators.js
+++ b/operators.js
@@ -107,9 +107,13 @@ function equal(seek, target, opts) {
   const value = toBufferOrFalsy(target)
   const valueName = !value ? '' : value.toString()
   const indexType = opts.indexType
-  const indexName = opts.prefix
-    ? safeFilename(indexType)
-    : safeFilename(indexType + '_' + valueName)
+  const indexName = safeFilename(
+    opts.prefix
+      ? opts.useMap
+        ? indexType + '_map'
+        : indexType
+      : indexType + '_' + valueName
+  )
   return {
     type: 'EQUAL',
     data: {
@@ -117,6 +121,7 @@ function equal(seek, target, opts) {
       value,
       indexType,
       indexName,
+      useMap: opts.useMap,
       indexAll: opts.indexAll,
       prefix: opts.prefix,
     },

--- a/test/prefix.js
+++ b/test/prefix.js
@@ -301,3 +301,70 @@ prepareAndRunTest('Prefix equal', dir, (t, db, raf) => {
     })
   })
 })
+
+prepareAndRunTest('Prefix equal unknown value', dir, (t, db, raf) => {
+  const msg1 = { type: 'post', text: 'First', channel: 'foo' }
+  const msg2 = { type: 'contact', text: 'Second' }
+  const msg3 = { type: 'post', text: 'Third' }
+
+  let state = validate.initial()
+  state = validate.appendNew(state, null, keys, msg1, Date.now())
+  state = validate.appendNew(state, null, keys, msg2, Date.now() + 1)
+  state = validate.appendNew(state, null, keys, msg3, Date.now() + 2)
+
+  const typeQuery = {
+    type: 'EQUAL',
+    data: {
+      seek: helpers.seekAuthor,
+      value: Buffer.from('abc'),
+      indexType: 'author',
+      prefix: 32,
+    },
+  }
+
+  addMsg(state.queue[0].value, raf, (err, msg) => {
+    addMsg(state.queue[1].value, raf, (err, msg) => {
+      addMsg(state.queue[2].value, raf, (err, msg) => {
+        db.all(typeQuery, 0, false, false, (err, results) => {
+          t.equal(results.length, 0)
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+prepareAndRunTest('Prefix map equal', dir, (t, db, raf) => {
+  const msg1 = { type: 'post', text: 'Testing!' }
+  const msg2 = { type: 'contact', text: 'Testing!' }
+  const msg3 = { type: 'post', text: 'Testing 2!' }
+
+  let state = validate.initial()
+  state = validate.appendNew(state, null, keys, msg1, Date.now())
+  state = validate.appendNew(state, null, keys, msg2, Date.now() + 1)
+  state = validate.appendNew(state, null, keys, msg3, Date.now() + 2)
+
+  const typeQuery = {
+    type: 'EQUAL',
+    data: {
+      seek: helpers.seekType,
+      value: Buffer.from('post'),
+      indexType: 'type',
+      useMap: true,
+      prefix: 32,
+    },
+  }
+
+  addMsg(state.queue[0].value, raf, (err, msg) => {
+    addMsg(state.queue[1].value, raf, (err, msg) => {
+      addMsg(state.queue[2].value, raf, (err, msg) => {
+        db.all(typeQuery, 0, false, false, (err, results) => {
+          t.equal(results.length, 2)
+          t.equal(results[0].value.content.type, 'post')
+          t.equal(results[1].value.content.type, 'post')
+          t.end()
+        })
+      })
+    })
+  })
+})

--- a/test/save-load.js
+++ b/test/save-load.js
@@ -6,6 +6,8 @@ const mkdirp = require('mkdirp')
 const {
   saveTypedArrayFile,
   loadTypedArrayFile,
+  savePrefixMapFile,
+  loadPrefixMapFile,
   saveBitsetFile,
   loadBitsetFile,
 } = require('../files')
@@ -89,6 +91,30 @@ test('save and load TypedArray for timestamp', (t) => {
         loadTypedArrayFile(filename, Float64Array, (err, loadedIdx2) => {
           for (var i = 0; i < 11; i += 1)
             t.equal(loadedIdx.tarr[i], loadedIdx2.tarr[i])
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+test('save and load prefix map', (t) => {
+  const idxDir = path.join(dir, 'indexesSaveLoadPrefix')
+  mkdirp.sync(idxDir)
+  const filename = path.join(idxDir, 'test.index')
+
+  var map = { 1: [1, 2, 3] }
+
+  savePrefixMapFile(filename, 1, 123, 10, map, (err) => {
+    loadPrefixMapFile(filename, (err, loadedIdx) => {
+      t.error(err, 'no error')
+      t.deepEqual(map, loadedIdx.map)
+
+      map[2] = [1, 2]
+
+      savePrefixMapFile(filename, 1, 1234, 11, map, (err) => {
+        loadPrefixMapFile(filename, (err, loadedIdx2) => {
+          t.deepEqual(map, loadedIdx2.map)
           t.end()
         })
       })


### PR DESCRIPTION
This took a while to wrap my head around. Basically before we were making it easy to create prefix indexes (just insert into tarr), but slow to query them loop. Instead lets optimize for the query because prefix indexes are used for very often used queries (key, votes, hasRoot etc.). The natural choice was to store prefixes as maps instead of arrays. Mapping the lookup key to sequences. Besides a bit slower index creation (25-70%) the size has almost doubled. I did not find a better solution than just storing them JSON stringified, but I'm sure there is a better way because we are just storing numbers here.

Query numbers for already created indexes using [perf](https://github.com/ssb-ngi-pointer/ssb-db2/pull/136) script:

## old

```
running: key initial
query: 130.071ms
running: key 2
query: 16.11ms
running: key again
query: 14.645ms
running: latest root posts
query: 88.219ms
running: latest posts
query: 166.388ms
running: votes initial
query: 43.506ms
running: votes 2
query: 11.124ms
running: votes again
query: 4.939ms
running: author posts
query: 225.619ms
running: author posts again
query: 39.766ms
```

## new

```
running: key initial
query: 294.774ms
running: key 2
query: 10.437ms
running: key again
query: 8.192ms
running: latest root posts
query: 77.361ms
running: latest posts
query: 137.998ms
running: votes initial
query: 93.16ms
running: votes 2
query: 0.902ms
running: votes again
query: 0.796ms
running: author posts
query: 414.573ms
running: author posts again
query: 33.201ms
```
