### PR TITLE
Only run one index create / update concurrently

### DIFF
--- a/index.js
+++ b/index.js
@@ -371,7 +371,7 @@ module.exports = function (log, indexesPath) {
   }
 
   // concurrent index update
-  const waitingIndexUpdate = {}
+  const waitingIndexUpdate = new Map()
 
   function updateIndex(op, cb) {
     const index = indexes[op.data.indexName]
@@ -464,12 +464,14 @@ module.exports = function (log, indexesPath) {
   }
 
   // concurrent index create
-  const waitingIndexCreate = {}
+  const waitingIndexCreate = new Map()
 
   function createIndexes(opsMissingIndexes, cb) {
     const newIndexes = {}
 
-    const waitingKey = opsMissingIndexes.join()
+    const waitingKey = opsMissingIndexes
+      .map((op) => op.data.indexName)
+      .join('|')
     if (waitingIndexCreate[waitingKey]) {
       waitingIndexCreate[waitingKey].push(cb)
       return // wait for other index create

--- a/index.js
+++ b/index.js
@@ -377,10 +377,10 @@ module.exports = function (log, indexesPath) {
     const index = indexes[op.data.indexName]
 
     const waitingKey = op.data.indexName
-    if (waitingIndexUpdate[waitingKey]) {
-      waitingIndexUpdate[waitingKey].push(cb)
+    if (waitingIndexUpdate.has(waitingKey)) {
+      waitingIndexUpdate.get(waitingKey).push(cb)
       return // wait for other index update
-    } else waitingIndexUpdate[waitingKey] = []
+    } else waitingIndexUpdate.set(waitingKey, [])
 
     // find the next possible seq
     let seq = 0
@@ -455,8 +455,8 @@ module.exports = function (log, indexesPath) {
           else saveIndex(op.data.indexName, index)
         }
 
-        waitingIndexUpdate[waitingKey].forEach((cb) => cb())
-        delete waitingIndexUpdate[waitingKey]
+        waitingIndexUpdate.get(waitingKey).forEach((cb) => cb())
+        waitingIndexUpdate.delete(waitingKey)
 
         cb()
       },
@@ -472,10 +472,10 @@ module.exports = function (log, indexesPath) {
     const waitingKey = opsMissingIndexes
       .map((op) => op.data.indexName)
       .join('|')
-    if (waitingIndexCreate[waitingKey]) {
-      waitingIndexCreate[waitingKey].push(cb)
-      return // wait for other index create
-    } else waitingIndexCreate[waitingKey] = []
+    if (waitingIndexCreate.has(waitingKey)) {
+      waitingIndexCreate.get(waitingKey).push(cb)
+      return // wait for other index update
+    } else waitingIndexCreate.set(waitingKey, [])
 
     opsMissingIndexes.forEach((op) => {
       if (op.data.prefix && op.data.useMap) {
@@ -571,8 +571,8 @@ module.exports = function (log, indexesPath) {
           else saveIndex(indexName, index)
         }
 
-        waitingIndexCreate[waitingKey].forEach((cb) => cb())
-        delete waitingIndexCreate[waitingKey]
+        waitingIndexCreate.get(waitingKey).forEach((cb) => cb())
+        waitingIndexCreate.delete(waitingKey)
 
         cb()
       },

--- a/test/prefix.js
+++ b/test/prefix.js
@@ -29,6 +29,7 @@ prepareAndRunTest('Prefix equal', dir, (t, db, raf) => {
       seek: helpers.seekType,
       value: Buffer.from('post'),
       indexType: 'type',
+      indexName: 'value_content_type_post',
       prefix: 32,
     },
   }
@@ -113,7 +114,7 @@ prepareAndRunTest('Prefix index skips deleted records', dir, (t, db, raf) => {
       seek: helpers.seekType,
       value: Buffer.from('post'),
       indexType: 'type',
-      indexName: 'value_content_type',
+      indexName: 'value_content_type_post',
       prefix: 32,
     },
   }
@@ -125,7 +126,7 @@ prepareAndRunTest('Prefix index skips deleted records', dir, (t, db, raf) => {
       seek: helpers.seekType,
       value: Buffer.from('post'),
       indexType: 'type',
-      indexName: 'value_content_type',
+      indexName: 'value_content_type_post',
       prefix: 32,
     },
   }
@@ -168,6 +169,7 @@ prepareAndRunTest('Prefix larger than actual value', dir, (t, db, raf) => {
       seek: helpers.seekChannel,
       value: Buffer.from('foo'),
       indexType: 'channel',
+      indexName: 'value_content_channel_foo',
       prefix: 32,
     },
   }
@@ -201,6 +203,7 @@ prepareAndRunTest('Prefix equal falsy', dir, (t, db, raf) => {
       seek: helpers.seekChannel,
       value: null,
       indexType: 'channel',
+      indexName: 'value_content_channel_',
       prefix: 32,
     },
   }
@@ -264,6 +267,8 @@ prepareAndRunTest('Prefix equal', dir, (t, db, raf) => {
         '%wOtfXXopI3mTHL6F7Y3XXNtpxws9mQdaEocNJuKtAZo=.sha256'
       ),
       indexType: 'vote',
+      indexName:
+        'value_content_vote_link_%wOtfXXopI3mTHL6F7Y3XXNtpxws9mQdaEocNJuKtAZo=.sha256',
       prefix: 32,
     },
   }
@@ -318,6 +323,7 @@ prepareAndRunTest('Prefix equal unknown value', dir, (t, db, raf) => {
       seek: helpers.seekAuthor,
       value: Buffer.from('abc'),
       indexType: 'author',
+      indexName: 'value_author_abc',
       prefix: 32,
     },
   }
@@ -350,6 +356,7 @@ prepareAndRunTest('Prefix map equal', dir, (t, db, raf) => {
       seek: helpers.seekType,
       value: Buffer.from('post'),
       indexType: 'type',
+      indexName: 'value_content_type_post',
       useMap: true,
       prefix: 32,
     },


### PR DESCRIPTION
Converting ssb-about to use jitdb revealed that jitdb doesn't handle concurrent index creates very well. Meaning it will just run as many in parallel as you give it ;) This PR remedies so that only one is running and just calls the waiting after it has finished. Massively faster. There is one caveat this PR handles the simple case of multiple `and(vote())`. But doesn't handle two concurrent requst like `and(author(), isPublic())` and `and(author())`. I don't think this will be a big problem in real life and I value the simplicity of this approach.

Not exactly sure how to write a good test for this. I testing this manually by doing two queries concurrently and with the PR you results in half the time.