### PR TITLE
Add prefixOffset option

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,11 @@ inverted index that allows for faster queries at the cost of extra
 space. Maps don't store empty values meaning they are also a good fit
 for sparce indexes such as vote links.
 
+It is possible specifiy where in the target the prefix buffer should
+be constructed from using `prefixOffset`. This is useful for targets
+that starts with a common prefix such as % in order to increase the
+information amount.
+
 ## Low-level API
 
 First some terminology: offset refers to the byte position in the log

--- a/index.js
+++ b/index.js
@@ -302,13 +302,13 @@ module.exports = function (log, indexesPath) {
     }
   }
 
-  function safeReadUint32(buf, offset) {
+  function safeReadUint32(buf, prefixOffset = 0) {
     if (buf.length < 4) {
       const bigger = Buffer.alloc(4)
       buf.copy(bigger)
-      return bigger.readUInt32LE(offset)
+      return bigger.readUInt32LE(prefixOffset)
     } else {
-      return buf.readUInt32LE(offset)
+      return buf.readUInt32LE(prefixOffset)
     }
   }
 
@@ -324,11 +324,10 @@ module.exports = function (log, indexesPath) {
       const fieldStart = opData.seek(buffer)
       if (~fieldStart) {
         const buf = bipf.slice(buffer, fieldStart)
-        const offset = opData.prefixOffset ? opData.prefixOffset : 0
         addToPrefixMap(
           index.map,
           seq,
-          buf.length ? safeReadUint32(buf, offset) : 0
+          buf.length ? safeReadUint32(buf, opData.prefixOffset) : 0
         )
       }
 
@@ -344,8 +343,9 @@ module.exports = function (log, indexesPath) {
       const fieldStart = opData.seek(buffer)
       if (~fieldStart) {
         const buf = bipf.slice(buffer, fieldStart)
-        const offset = opData.prefixOffset ? opData.prefixOffset : 0
-        index.tarr[seq] = buf.length ? safeReadUint32(buf, offset) : 0
+        index.tarr[seq] = buf.length
+          ? safeReadUint32(buf, opData.prefixOffset)
+          : 0
       } else {
         index.tarr[seq] = 0
       }
@@ -689,8 +689,9 @@ module.exports = function (log, indexesPath) {
 
   function matchAgainstPrefix(op, prefixIndex, cb) {
     const target = op.data.value
-    const targetOffset = op.data.prefixOffset ? op.data.prefixOffset : 0
-    const targetPrefix = target ? safeReadUint32(target, targetOffset) : 0
+    const targetPrefix = target
+      ? safeReadUint32(target, op.data.prefixOffset)
+      : 0
     const bitset = new TypedFastBitSet()
     const done = multicb({ pluck: 1 })
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,5 +1,6 @@
 const bipf = require('bipf')
 
+const bKey = Buffer.from('key')
 const bValue = Buffer.from('value')
 const bVote = Buffer.from('vote')
 const bLink = Buffer.from('link')
@@ -14,6 +15,11 @@ const bPrivate = Buffer.from('private')
 const bChannel = Buffer.from('channel')
 
 module.exports = {
+  seekKey: function (buffer) {
+    var p = 0 // note you pass in p!
+    return bipf.seekKey(buffer, p, bKey)
+  },
+
   seekAuthor: function (buffer) {
     var p = 0 // note you pass in p!
     p = bipf.seekKey(buffer, p, bValue)


### PR DESCRIPTION
Makes it possible specifiy where in the target the prefix buffer should be constructed from. 

Some motivation [here](https://github.com/ssb-ngi-pointer/ssb-db2/pull/137), it will make some certain prefix indexes much faster.