### PR TITLE
Few fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -983,7 +983,6 @@ module.exports = function (log, indexesPath) {
     cb
   ) {
     seq = seq || 0
-    const start = Date.now()
 
     const sorted = sortedByTimestamp(bitset, descending)
     const sliced =
@@ -1004,7 +1003,6 @@ module.exports = function (log, indexesPath) {
         cb(err, {
           results: results,
           total: sorted.length,
-          duration: Date.now() - start,
         })
       })
     )
@@ -1017,6 +1015,7 @@ module.exports = function (log, indexesPath) {
 
   function paginate(operation, seq, limit, descending, onlyOffset, cb) {
     onReady(() => {
+      const start = Date.now()
       executeOperation(operation, (bitset) => {
         getMessagesFromBitsetSlice(
           bitset,
@@ -1027,6 +1026,7 @@ module.exports = function (log, indexesPath) {
           (err, answer) => {
             if (err) cb(err)
             else {
+              answer.duration = Date.now() - start
               debugQuery.enabled &&
                 debugQuery(
                   `paginate(${getNameFromOperation(operation)}): ${
@@ -1043,6 +1043,7 @@ module.exports = function (log, indexesPath) {
 
   function all(operation, seq, descending, onlyOffset, cb) {
     onReady(() => {
+      const start = Date.now()
       executeOperation(operation, (bitset) => {
         getMessagesFromBitsetSlice(
           bitset,
@@ -1053,6 +1054,7 @@ module.exports = function (log, indexesPath) {
           (err, answer) => {
             if (err) cb(err)
             else {
+              answer.duration = Date.now() - start
               debugQuery.enabled &&
                 debugQuery(
                   `all(${getNameFromOperation(operation)}): ${

--- a/test/operators.js
+++ b/test/operators.js
@@ -58,8 +58,16 @@ prepareAndRunTest('operators API supports equal', dir, (t, db, raf) => {
   t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
 
   t.equal(typeof queryTree.meta, 'object', 'queryTree contains meta')
-  t.equal(typeof queryTree.meta.db, 'object', 'queryTree contains meta.db')
-  t.equal(typeof queryTree.meta.db.onReady, 'function', 'meta.db looks correct')
+  t.equal(
+    typeof queryTree.meta.jitdb,
+    'object',
+    'queryTree contains meta.jitdb'
+  )
+  t.equal(
+    typeof queryTree.meta.jitdb.onReady,
+    'function',
+    'meta.jitdb looks correct'
+  )
 
   t.end()
 })
@@ -80,8 +88,16 @@ prepareAndRunTest('operators API supports slowEqual', dir, (t, db, raf) => {
   t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
 
   t.equal(typeof queryTree.meta, 'object', 'queryTree contains meta')
-  t.equal(typeof queryTree.meta.db, 'object', 'queryTree contains meta.db')
-  t.equal(typeof queryTree.meta.db.onReady, 'function', 'meta.db looks correct')
+  t.equal(
+    typeof queryTree.meta.jitdb,
+    'object',
+    'queryTree contains meta.jitdb'
+  )
+  t.equal(
+    typeof queryTree.meta.jitdb.onReady,
+    'function',
+    'meta.jitdb looks correct'
+  )
 
   t.end()
 })
@@ -103,8 +119,16 @@ prepareAndRunTest('query ignores non-function arguments', dir, (t, db, raf) => {
   t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
 
   t.equal(typeof queryTree.meta, 'object', 'queryTree contains meta')
-  t.equal(typeof queryTree.meta.db, 'object', 'queryTree contains meta.db')
-  t.equal(typeof queryTree.meta.db.onReady, 'function', 'meta.db looks correct')
+  t.equal(
+    typeof queryTree.meta.jitdb,
+    'object',
+    'queryTree contains meta.jitdb'
+  )
+  t.equal(
+    typeof queryTree.meta.jitdb.onReady,
+    'function',
+    'meta.jitdb looks correct'
+  )
 
   t.end()
 })
@@ -128,8 +152,16 @@ prepareAndRunTest('and() ignores non-function arguments', dir, (t, db, raf) => {
   t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
 
   t.equal(typeof queryTree.meta, 'object', 'queryTree contains meta')
-  t.equal(typeof queryTree.meta.db, 'object', 'queryTree contains meta.db')
-  t.equal(typeof queryTree.meta.db.onReady, 'function', 'meta.db looks correct')
+  t.equal(
+    typeof queryTree.meta.jitdb,
+    'object',
+    'queryTree contains meta.jitdb'
+  )
+  t.equal(
+    typeof queryTree.meta.jitdb.onReady,
+    'function',
+    'meta.jitdb looks correct'
+  )
 
   t.end()
 })
@@ -153,8 +185,16 @@ prepareAndRunTest('or() ignores non-function arguments', dir, (t, db, raf) => {
   t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
 
   t.equal(typeof queryTree.meta, 'object', 'queryTree contains meta')
-  t.equal(typeof queryTree.meta.db, 'object', 'queryTree contains meta.db')
-  t.equal(typeof queryTree.meta.db.onReady, 'function', 'meta.db looks correct')
+  t.equal(
+    typeof queryTree.meta.jitdb,
+    'object',
+    'queryTree contains meta.jitdb'
+  )
+  t.equal(
+    typeof queryTree.meta.jitdb.onReady,
+    'function',
+    'meta.jitdb looks correct'
+  )
 
   t.end()
 })


### PR DESCRIPTION
Two problems that I'm trying to solve:

(A) the durations in `paginate()` and `all()` seemed to be wrong because they only measured `getMessagesFromBitsetSlice`, not including `executeOperation`. I fixed that

(B) In ssb-db2, we attach `meta.db2`, alongside the existing `meta.db`. I think future developers might run into some WTFs as they try to understand what is "db" when it can refer to ssb-db, jitdb, or ssb-db2 (e.g. `sbot.db.get`). So to make things easier, I decided to not call jitdb "db". So I made a rename. :warning: This is a breaking change, and we should update ssb-db2 ASAP.