### PR TITLE
operators should pass prefixOffset onwards

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -190,8 +190,20 @@ test('query three indexes (first run)', (t) => {
       fromDB(db),
       or(
         and(equal(seekType, 'contact', { indexType: 'type' })),
-        and(equal(seekAuthor, alice.id, { indexType: 'author', prefix: 32 })),
-        and(equal(seekAuthor, bob.id, { indexType: 'author', prefix: 32 }))
+        and(
+          equal(seekAuthor, alice.id, {
+            indexType: 'author',
+            prefix: 32,
+            prefixOffset: 1,
+          })
+        ),
+        and(
+          equal(seekAuthor, bob.id, {
+            indexType: 'author',
+            prefix: 32,
+            prefixOffset: 1,
+          })
+        )
       ),
       toCallback((err, msgs) => {
         if (err) t.fail(err)
@@ -219,8 +231,20 @@ test('query three indexes (second run)', (t) => {
       fromDB(db),
       or(
         and(equal(seekType, 'contact', { indexType: 'type' })),
-        and(equal(seekAuthor, alice.id, { indexType: 'author', prefix: 32 })),
-        and(equal(seekAuthor, bob.id, { indexType: 'author', prefix: 32 }))
+        and(
+          equal(seekAuthor, alice.id, {
+            indexType: 'author',
+            prefix: 32,
+            prefixOffset: 1,
+          })
+        ),
+        and(
+          equal(seekAuthor, bob.id, {
+            indexType: 'author',
+            prefix: 32,
+            prefixOffset: 1,
+          })
+        )
       ),
       toCallback((err, msgs) => {
         if (err) t.fail(err)
@@ -257,8 +281,20 @@ test('load two indexes concurrently', (t) => {
       fromDB(db),
       or(
         and(equal(seekType, 'contact', { indexType: 'type' })),
-        and(equal(seekAuthor, alice.id, { indexType: 'author', prefix: 32 })),
-        and(equal(seekAuthor, bob.id, { indexType: 'author', prefix: 32 }))
+        and(
+          equal(seekAuthor, alice.id, {
+            indexType: 'author',
+            prefix: 32,
+            prefixOffset: 1,
+          })
+        ),
+        and(
+          equal(seekAuthor, bob.id, {
+            indexType: 'author',
+            prefix: 32,
+            prefixOffset: 1,
+          })
+        )
       ),
       toCallback(done())
     )
@@ -267,8 +303,20 @@ test('load two indexes concurrently', (t) => {
       fromDB(db),
       or(
         and(equal(seekType, 'contact', { indexType: 'type' })),
-        and(equal(seekAuthor, alice.id, { indexType: 'author', prefix: 32 })),
-        and(equal(seekAuthor, bob.id, { indexType: 'author', prefix: 32 }))
+        and(
+          equal(seekAuthor, alice.id, {
+            indexType: 'author',
+            prefix: 32,
+            prefixOffset: 1,
+          })
+        ),
+        and(
+          equal(seekAuthor, bob.id, {
+            indexType: 'author',
+            prefix: 32,
+            prefixOffset: 1,
+          })
+        )
       ),
       toCallback(done())
     )
@@ -338,6 +386,7 @@ test('query a prefix map (first run)', (t) => {
                   indexType: 'value_content_vote_link',
                   useMap: true,
                   prefix: 32,
+                  prefixOffset: 1,
                 })
               ),
               paginate(5),
@@ -386,6 +435,7 @@ test('query a prefix map (second run)', (t) => {
                   indexType: 'value_content_vote_link',
                   useMap: true,
                   prefix: 32,
+                  prefixOffset: 1,
                 })
               ),
               paginate(5),

--- a/operators.js
+++ b/operators.js
@@ -105,6 +105,7 @@ function slowEqual(seekDesc, target, opts) {
       useMap: opts.useMap,
       indexAll: opts.indexAll,
       prefix: opts.prefix,
+      prefixOffset: opts.prefixOffset,
     },
   }
 }
@@ -127,6 +128,7 @@ function equal(seek, target, opts) {
       useMap: opts.useMap,
       indexAll: opts.indexAll,
       prefix: opts.prefix,
+      prefixOffset: opts.prefixOffset,
     },
   }
 }


### PR DESCRIPTION
I was doing `cat value_author.32prefix | xxd -c 8` on mobile and I kept seeing those `@` sigil in front and thinking "what on Earth, I have the most recent version of db2". Then I looked into the code in JITDB and :sweat_smile: 