### PR TITLE
Faster sort

### DIFF
--- a/index.js
+++ b/index.js
@@ -1066,7 +1066,7 @@ module.exports = function (log, indexesPath) {
 
   function countBitsetSlice(bitset, seq, descending) {
     if (!seq) return bitset.size()
-    else return
+    else return bitset.size() - seq
   }
 
   function paginate(operation, seq, limit, descending, onlyOffset, cb) {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "binary-search-bounds": "^2.0.4",
     "bipf": "^1.4.0",
     "debug": "^4.2.0",
+    "fastpriorityqueue": "^0.6.3",
     "idb-kv-store": "^4.5.0",
     "jsesc": "^3.0.2",
     "mkdirp": "^1.0.4",

--- a/test/query.js
+++ b/test/query.js
@@ -726,17 +726,20 @@ prepareAndRunTest('Timestamp discontinuity', dir, (t, db, raf) => {
     },
   }
 
-  addMsg(state.queue[0].value, raf, (err, m1) => {
-    addMsg(state.queue[1].value, raf, (err, m2) => {
-      addMsg(state.queue[2].value, raf, (err, m3) => {
-        db.all(authorQuery, 0, false, false, (err, results) => {
-          t.equal(results.length, 3)
-          t.equal(results[0].value.content.text, '1st', '1st ok')
-          t.equal(results[1].value.content.text, '2nd', '2nd ok')
-          t.equal(results[2].value.content.text, '3rd', '3rd ok')
-          t.end()
+  // we need to wait for the declared timestamps to win over arrival
+  setTimeout(() => {
+    addMsg(state.queue[0].value, raf, (err, m1) => {
+      addMsg(state.queue[1].value, raf, (err, m2) => {
+        addMsg(state.queue[2].value, raf, (err, m3) => {
+          db.all(authorQuery, 0, false, false, (err, results) => {
+            t.equal(results.length, 3)
+            t.equal(results[0].value.content.text, '3rd', '3rd ok')
+            t.equal(results[1].value.content.text, '2nd', '2nd ok')
+            t.equal(results[2].value.content.text, '1st', '1st ok')
+            t.end()
+          })
         })
       })
     })
-  })
+  }, 3000)
 })

--- a/test/query.js
+++ b/test/query.js
@@ -709,10 +709,12 @@ prepareAndRunTest('Timestamp discontinuity', dir, (t, db, raf) => {
   const msg2 = { type: 'post', text: '2nd' }
   const msg3 = { type: 'post', text: '3rd' }
 
+  const start = Date.now()
+
   let state = validate.initial()
-  state = validate.appendNew(state, null, keys, msg1, Date.now() + 3000)
-  state = validate.appendNew(state, null, keys, msg2, Date.now() + 2000)
-  state = validate.appendNew(state, null, keys, msg3, Date.now() + 1000)
+  state = validate.appendNew(state, null, keys, msg1, start + 3000)
+  state = validate.appendNew(state, null, keys, msg2, start + 2000)
+  state = validate.appendNew(state, null, keys, msg3, start + 1000)
 
   const authorQuery = {
     type: 'EQUAL',


### PR DESCRIPTION
This is a PR to improve the performance of paginated queries with a large number of results. The main bottleneck was the sorting of the result set before doing a slice. I tried a lot of different sorting techniques including radix sort but they all had a drawback that made them not quite right. Instead I started looking and though, our old friend Lemire must have thought about this problem, lo and behold he [has](https://lemire.me/blog/2017/06/21/top-speed-for-top-k-queries/): *We can sort and slice...*

The idea is to use a priority queue instead of sorting the array and plucking elements from that instead. I was a bit concerned with the clone() call in the sortedCache but that turns out to be still of value. 

# Old 

public (post + contact): 545 ms
public (post + contact) page 2: 551 ms (total for page 1+2)
private (post + contact): 50 ms

# New

public (post + contact): 214 ms
public (post + contact) page 2: 241 ms (total for page 1+2)
private (post + contact): 50 ms
