### PR TITLE
paginate() with limit=0 should return zero results

### DIFF
--- a/index.js
+++ b/index.js
@@ -1062,7 +1062,7 @@ module.exports = function (log, indexesPath) {
     const resultSize = sorted.size
 
     let sliced
-    if (resultSize === 0 || limit < 0) {
+    if (resultSize === 0 || limit <= 0) {
       sliced = []
     } else if (seq === 0 && limit === 1) {
       sliced = [sorted.peek()]
@@ -1132,7 +1132,7 @@ module.exports = function (log, indexesPath) {
         getMessagesFromBitsetSlice(
           bitset,
           seq,
-          null,
+          Infinity,
           descending,
           onlyOffset,
           (err, answer) => {

--- a/test/query.js
+++ b/test/query.js
@@ -121,6 +121,31 @@ prepareAndRunTest('Limit -1', dir, (t, db, raf) => {
   })
 })
 
+prepareAndRunTest('Limit 0', dir, (t, db, raf) => {
+  const msg1 = { type: 'post', text: 'Testing limit 0' }
+
+  let state = validate.initial()
+  state = validate.appendNew(state, null, keys, msg1, Date.now())
+
+  const typeQuery = {
+    type: 'EQUAL',
+    data: {
+      seek: helpers.seekType,
+      value: Buffer.from('post'),
+      indexType: 'type',
+      indexName: 'type_post',
+    },
+  }
+
+  addMsg(state.queue[0].value, raf, (err, msg) => {
+    db.paginate(typeQuery, 0, 0, true, false, (err2, { results }) => {
+      t.error(err2)
+      t.equal(results.length, 0)
+      t.end()
+    })
+  })
+})
+
 prepareAndRunTest('Includes', dir, (t, db, raf) => {
   const msg1 = { type: 'post', text: '1st', animals: ['cat', 'dog', 'bird'] }
   const msg2 = { type: 'contact', text: '2nd', animals: ['bird'] }


### PR DESCRIPTION
Before, we were using falsy values of `limit` to mean "everything". Now, falsy values mean "Infinity", and `db.all` will use `Infinity`. So `limit=0` is not anymore interpreted as falsy, it's interpreted as zero, and the results are thus empty.