### PR TITLE
dont consider lt/lte/gt/gte unknown operators

### DIFF
--- a/index.js
+++ b/index.js
@@ -955,6 +955,10 @@ module.exports = function (log, indexesPath) {
           op.type === 'SEQS' ||
           op.type === 'LIVESEQS' ||
           op.type === 'OFFSETS' ||
+          op.type === 'LT' ||
+          op.type === 'LTE' ||
+          op.type === 'GT' ||
+          op.type === 'GTE' ||
           !op.type // e.g. query(fromDB, toCallback), or empty deferred()
         );
         else debug('Unknown operator type: ' + op.type)


### PR DESCRIPTION
I saw a `"Unknown operator type: GTE"` in my logs and it didn't seem necessary, because GT/GTE/LT/LTE are not weird operators.

Doesn't change runtime behavior, just changes `debug()` calls.