### PR TITLE
Optimize edge cases for getMessagesFromBitsetSlice

### DIFF
--- a/index.js
+++ b/index.js
@@ -1066,18 +1066,19 @@ module.exports = function (log, indexesPath) {
 
     let sorted = sortedByTimestamp(bitset, descending)
     const resultSize = sorted.size
-
     let sliced
-    if (resultSize === 0 || limit <= 0) {
+    if (limit < 1 || resultSize < 1) {
       sliced = []
-    } else if (seq === 0 && limit === 1) {
-      sliced = [sorted.peek()]
     } else {
       if (seq > 0) {
         sorted = sorted.clone()
         sorted.removeMany(() => true, seq)
       }
-      sliced = sorted.kSmallest(limit || Infinity)
+      if (limit < 2) {
+        sliced = [sorted.peek()]
+      } else {
+        sliced = sorted.kSmallest(limit || Infinity)
+      }
     }
 
     push(


### PR DESCRIPTION
I attempted some optimizations to `getMessagesFromBitsetSlice`.

- Use simpler comparisons where possible
- Prefer `peek` over `kSmallest` when returning a single element, not only for zero offset
  - [The queue lib](https://github.com/lemire/FastPriorityQueue.js/blob/master/FastPriorityQueue.js#L274) seems way less efficient for kSmallest at size one

I'm not terribly familiar w/ this codebase, so let me know if I'm missing something here.