### PR TITLE
Improve Pagination Performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "binary-search-bounds": "^2.0.4",
     "bipf": "^1.4.0",
     "debug": "^4.2.0",
-    "fastpriorityqueue": "^0.6.3",
+    "fastpriorityqueue": "^0.7.0",
     "idb-kv-store": "^4.5.0",
     "jsesc": "^3.0.2",
     "mkdirp": "^1.0.4",


### PR DESCRIPTION
This MR uses alternative `kSmallest` and `clone` methods for the FastPriorityQueue to speed up `getMessagesFromBitsetSlice`. I also submitted these changes to [lemire/FastPriorityQueue.js](https://github.com/lemire/FastPriorityQueue.js/pull/29).

I don't think I have the right permissions, so the benchmark job will probably fail to add a comment (so you'll need to examine the job to see results). Based on my own testing, this seems to double performance for pagination over small page sizes and somewhat improves performance for large page sizes.