### PR TITLE
Make or operator consistent at top level vs nested - see #138

### DIFF
--- a/operators.js
+++ b/operators.js
@@ -290,18 +290,16 @@ function or(...args) {
       .map((arg) => (typeof arg === 'function' ? arg(ops, true) : arg))
       .filter((arg) => !!arg)
     const res =
-      ops && ops.type && !isSpecialOps
-        ? {
-            type: 'OR',
-            data: [ops, ...rhs],
-          }
-        : rhs.length > 1
+      rhs.length > 1
         ? {
             type: 'OR',
             data: rhs,
           }
         : rhs[0]
     if (ops) copyMeta(ops, res)
+    if (!isSpecialOps) {
+      return and(res)(ops, isSpecialOps)
+    }
     return res
   }
 }

--- a/test/operators.js
+++ b/test/operators.js
@@ -663,6 +663,28 @@ prepareAndRunTest('count operator toPullStream', dir, (t, db, raf) => {
   })
 })
 
+prepareAndRunTest('operators - or - top-level', dir, (t, db, raf) => {
+  const msg = { type: 'post', text: 'Testing!' }
+  let state = validate.initial()
+  state = validate.appendNew(state, null, alice, msg, Date.now())
+  state = validate.appendNew(state, null, bob, msg, Date.now() + 1)
+
+  addMsg(state.queue[0].value, raf, (e1, msg1) => {
+    addMsg(state.queue[1].value, raf, (e2, msg2) => {
+      query(
+        fromDB(db),
+        and(slowEqual('value.author', alice.id)),
+        or(slowEqual('value.author', bob.id)),
+        toCallback((err, msgs) => {
+          t.error(err, 'toCallback got no error')
+          t.equal(msgs.length, 0, 'toCallback got no messages')
+          t.end()
+        })
+      )
+    })
+  })
+})
+
 prepareAndRunTest('operators fromDB then toCallback', dir, (t, db, raf) => {
   const msg = { type: 'post', text: 'Testing!' }
   let state = validate.initial()


### PR DESCRIPTION
This wraps the "or" operator an an "and" operator whenever it's included at the top level of a query.