### PR TITLE
Update FastPriorityQueue with removeMany bugfix

### DIFF
--- a/index.js
+++ b/index.js
@@ -1075,7 +1075,9 @@ module.exports = function (log, indexesPath) {
     } else {
       if (seq > 0) {
         sorted = sorted.clone()
-        sorted.removeMany(() => true, seq)
+        for (let j = 0; j < seq && !sorted.isEmpty(); j++) {
+          sorted.poll()
+        }
       }
       sliced = sorted.kSmallest(limit || Infinity)
     }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "binary-search-bounds": "^2.0.4",
     "bipf": "^1.4.0",
     "debug": "^4.2.0",
-    "fastpriorityqueue": "^0.6.4",
+    "fastpriorityqueue": "^0.7.1",
     "idb-kv-store": "^4.5.0",
     "jsesc": "^3.0.2",
     "mkdirp": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "binary-search-bounds": "^2.0.4",
     "bipf": "^1.4.0",
     "debug": "^4.2.0",
-    "fastpriorityqueue": "^0.7.0",
+    "fastpriorityqueue": "^0.6.4",
     "idb-kv-store": "^4.5.0",
     "jsesc": "^3.0.2",
     "mkdirp": "^1.0.4",


### PR DESCRIPTION
FYI some of the npm packages for `fastpriorityqueue` appear to be versioned incorrectly. This actually includes the enhancement from version `0.7.0` even though it appears to have a lower version number.

You can reference lemire/FastPriorityQueue.js#30 and lemire/FastPriorityQueue.js#31 for exactly what's fixed here. I believe your current usage of `removeMany` will be unaffected by the bug, but the fixed version may perform worse in your benchmarks. It may prevent bugs if someone updates that area of the code.