### PR TITLE
Delay checking prefix index until we need the result

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -263,15 +263,11 @@ test('load two indexes concurrently', (t) => {
   const bob = ssbKeys.loadOrCreateSync(path.join(dir, 'secret-b'))
 
   function waitForFile(filename, cb) {
-    fs.exists(filename, function(exists) {
-      if (exists) cb()
-      else setTimeout(() => waitForFile(filename, cb), 250)
-    })
+    if (fs.existsSync(filename)) cb()
+    else setTimeout(waitForFile, 250, filename, cb)
   }
 
   db.onReady(() => {
-    const done = multicb({ pluck: 1 })
-    const start = Date.now()
     const contact_index_filename = path.join(indexesDir, 'type_contact.index')
 
     // we need to wait for the other tests to write the index file
@@ -282,6 +278,9 @@ test('load two indexes concurrently', (t) => {
         lazy: true,
         filepath: contact_index_filename,
       }
+
+      const done = multicb({ pluck: 1 })
+      const start = Date.now()
 
       query(
         fromDB(db),

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -262,66 +262,77 @@ test('load two indexes concurrently', (t) => {
   const alice = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
   const bob = ssbKeys.loadOrCreateSync(path.join(dir, 'secret-b'))
 
+  function waitForFile(filename, cb) {
+    fs.exists(filename, function(exists) {
+      if (exists) cb()
+      else setTimeout(() => waitForFile(filename, cb), 250)
+    })
+  }
+
   db.onReady(() => {
     const done = multicb({ pluck: 1 })
     const start = Date.now()
+    const contact_index_filename = path.join(indexesDir, 'type_contact.index')
 
-    db.indexes['type_contact'] = {
-      offset: 0,
-      bitset: new TypedFastBitSet(),
-      lazy: true,
-      filepath: path.join(indexesDir, 'type_contact.index'),
-    }
+    // we need to wait for the other tests to write the index file
+    waitForFile(contact_index_filename, () => {
+      db.indexes['type_contact'] = {
+        offset: 0,
+        bitset: new TypedFastBitSet(),
+        lazy: true,
+        filepath: contact_index_filename,
+      }
 
-    query(
-      fromDB(db),
-      where(
-        or(
-          equal(seekType, 'contact', { indexType: 'type' }),
-          equal(seekAuthor, alice.id, {
-            indexType: 'author',
-            prefix: 32,
-            prefixOffset: 1,
-          }),
-          equal(seekAuthor, bob.id, {
-            indexType: 'author',
-            prefix: 32,
-            prefixOffset: 1,
-          })
-        )
-      ),
-      toCallback(done())
-    )
-
-    query(
-      fromDB(db),
-      where(
-        or(
-          equal(seekType, 'contact', { indexType: 'type' }),
-          equal(seekAuthor, alice.id, {
-            indexType: 'author',
-            prefix: 32,
-            prefixOffset: 1,
-          }),
-          equal(seekAuthor, bob.id, {
-            indexType: 'author',
-            prefix: 32,
-            prefixOffset: 1,
-          })
-        )
-      ),
-      toCallback(done())
-    )
-
-    done((err) => {
-      if (err) t.fail(err)
-      const duration = Date.now() - start
-      t.pass(`duration: ${duration}ms`)
-      fs.appendFileSync(
-        reportPath,
-        `| Load two indexes concurrently | ${duration}ms |\n`
+      query(
+        fromDB(db),
+        where(
+          or(
+            equal(seekType, 'contact', { indexType: 'type' }),
+            equal(seekAuthor, alice.id, {
+              indexType: 'author',
+              prefix: 32,
+              prefixOffset: 1,
+            }),
+            equal(seekAuthor, bob.id, {
+              indexType: 'author',
+              prefix: 32,
+              prefixOffset: 1,
+            })
+          )
+        ),
+        toCallback(done())
       )
-      t.end()
+
+      query(
+        fromDB(db),
+        where(
+          or(
+            equal(seekType, 'contact', { indexType: 'type' }),
+            equal(seekAuthor, alice.id, {
+              indexType: 'author',
+              prefix: 32,
+              prefixOffset: 1,
+            }),
+            equal(seekAuthor, bob.id, {
+              indexType: 'author',
+              prefix: 32,
+              prefixOffset: 1,
+            })
+          )
+        ),
+        toCallback(done())
+      )
+
+      done((err) => {
+        if (err) t.fail(err)
+        const duration = Date.now() - start
+        t.pass(`duration: ${duration}ms`)
+        fs.appendFileSync(
+          reportPath,
+          `| Load two indexes concurrently | ${duration}ms |\n`
+        )
+        t.end()
+      })
     })
   })
 })

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -538,7 +538,7 @@ test('paginate ten results', (t) => {
         t.pass(`duration: ${duration}ms`)
         fs.appendFileSync(
           reportPath,
-          `| paginate 10 results | ${duration}ms |\n`
+          `| Paginate 10 results | ${duration}ms |\n`
         )
         t.end()
       })

--- a/index.js
+++ b/index.js
@@ -877,6 +877,7 @@ module.exports = function (log, indexesPath) {
   }
 
   function mergeFilters(filters1, filters2) {
+    if (!filters1 && !filters2) return null
     const filters = filters1 || new Map()
     if (!filters2) return filters
     for (let seq of filters2.keys()) {

--- a/index.js
+++ b/index.js
@@ -881,7 +881,7 @@ module.exports = function (log, indexesPath) {
     else if (filters1 && !filters2) return filters1
     else if (!filters1 && filters2) return filters2
     else {
-      const filters = filters1
+      const filters = new Map(filters1)
       for (let seq of filters2.keys()) {
         const f1 = filters1.get(seq) || []
         const f2 = filters2.get(seq)

--- a/index.js
+++ b/index.js
@@ -878,14 +878,17 @@ module.exports = function (log, indexesPath) {
 
   function mergeFilters(filters1, filters2) {
     if (!filters1 && !filters2) return null
-    const filters = filters1 || new Map()
-    if (!filters2) return filters
-    for (let seq of filters2.keys()) {
-      const f1 = filters.get(seq) || []
-      const f2 = filters2.get(seq)
-      filters.set(seq, [...f1, ...f2])
+    else if (filters1 && !filters2) return filters1
+    else if (!filters1 && filters2) return filters2
+    else {
+      const filters = filters1
+      for (let seq of filters2.keys()) {
+        const f1 = filters1.get(seq) || []
+        const f2 = filters2.get(seq)
+        filters.set(seq, [...f1, ...f2])
+      }
+      return filters
     }
-    return filters
   }
 
   function getBitsetForOperation(op, cb) {

--- a/index.js
+++ b/index.js
@@ -1071,12 +1071,14 @@ module.exports = function (log, indexesPath) {
   }
 
   function filterRecord(seq, filters, recBufferCache, cb) {
+    const seqFilters = filters.get(seq)
+    if (!seqFilters) return cb(null, seq)
+
     getRecord(seq, (err, record) => {
       if (err) return cb(err)
 
       const recBuffer = record.value
       let ok = true
-      const seqFilters = filters.get(seq)
       if (seqFilters) ok = seqFilters.every((filter) => filter(recBuffer))
 
       if (ok) {


### PR DESCRIPTION
I was looking at the [performance of getting messages for a specific author](https://github.com/arj03/ssb-sync-test) and remembered there was one thing that I wanted to fix about prefix indexes, namely that it should be a bit more lazy about checking the messages it needs. Basically right now if you do query of: *give me the latest 10 messages from a specific author* it has to check all messages for that author to make sure that they match the prefix before it can sorted and results returned.

:warning: this changes the core structure of queries so should be reviewed carefully :warning: 

I made several rounds of this and the tests + benchmarks we have were quite useful in making sure that the code still works as before. I added an extra test to make sure that it works like I expected. Also this PR fixes a bug in the benchmarking code where we did not wait for an index to be written to disc before continuing and the bug was masked by the old code having to get a ton of messages from disc.

Benchmark results:

Before

```
db query warmup (10319): 2.985s
db query author all (8032): 959.953ms
db query author post msgs (2095): 617.328ms
db query author 10 msgs: 198.095ms
```

After:

```
db query warmup (10319): 1.013s
db query author all (8032): 760.335ms
db query author post msgs (2095): 236.625ms
db query author 10 msgs: 26.373ms
```