### PR TITLE
Only iterate once over the bitset results

### DIFF
--- a/index.js
+++ b/index.js
@@ -1059,7 +1059,7 @@ module.exports = function (log, indexesPath) {
     const fpq = new FastPriorityQueue(
       descending ? compareDescending : compareAscending
     )
-    bitset.array().forEach((seq) => {
+    bitset.forEach((seq) => {
       fpq.add({
         seq,
         timestamp: indexes['timestamp'].tarr[seq],


### PR DESCRIPTION
The iteration order using [`TypedFastBitSet.prototype.array`](https://github.com/lemire/TypedFastBitSet.js/blob/79866f74d0bf237153610a2ed80fc87e94f92a8d/TypedFastBitSet.js#L220) and [`TypedFastBitSet.prototype.forEach`](https://github.com/lemire/TypedFastBitSet.js/blob/79866f74d0bf237153610a2ed80fc87e94f92a8d/TypedFastBitSet.js#L236) are identical, but the former creates an intermediate array that we immediately discard. This PR removes the additional iteration overhead and intermediate array.