### PR TITLE
Implement slowEqual enhancement from #128

### DIFF
--- a/operators.js
+++ b/operators.js
@@ -34,13 +34,11 @@ function toBufferOrFalsy(value) {
 function seekFromDesc(desc) {
   const keys = desc.split('.')
   // The 2nd arg `start` is to support plucks too
+  const compiledSeek = bipf.createSeekPath(keys)
   return (buffer, start = 0) => {
-    var p = start
-    for (let key of keys) {
-      p = bipf.seekKey(buffer, p, Buffer.from(key))
-      if (!~p) return void 0
-    }
-    return p
+    const p = compiledSeek(buffer, start)
+    if (!~p) return void 0
+    else return p
   }
 }
 

--- a/test/operators.js
+++ b/test/operators.js
@@ -89,7 +89,7 @@ prepareAndRunTest('operators API supports slowEqual', dir, (t, db, raf) => {
   t.equal(queryTree.data.indexType, 'value_content_type')
   t.notOk(queryTree.data.indexAll)
   t.deepEqual(queryTree.data.value, Buffer.from('post'))
-  t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
+  t.true(queryTree.data.seek.toString().includes('compiledSeek'))
 
   t.equal(typeof queryTree.meta, 'object', 'queryTree contains meta')
   t.equal(
@@ -186,7 +186,7 @@ prepareAndRunTest('slowEqual 3 args', dir, (t, db, raf) => {
   t.equal(queryTree.data.indexType, 'value_content_type')
   t.equal(queryTree.data.indexAll, true)
   t.deepEqual(queryTree.data.value, Buffer.from('post'))
-  t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
+  t.true(queryTree.data.seek.toString().includes('compiledSeek'))
 
   t.end()
 })
@@ -253,7 +253,7 @@ prepareAndRunTest('slowEqual with prefix', dir, (t, db, raf) => {
 
   t.equal(queryTree.data.indexType, 'value_content_type')
   t.deepEqual(queryTree.data.value, Buffer.from('post'))
-  t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
+  t.true(queryTree.data.seek.toString().includes('compiledSeek'))
   t.equal(queryTree.data.prefix, 32)
 
   t.end()
@@ -300,14 +300,14 @@ prepareAndRunTest('operators API supports or()', dir, (t, db, raf) => {
   t.deepEqual(queryTree.data[1].data[0].data.indexType, 'value_author')
   t.deepEqual(queryTree.data[1].data[0].data.value, Buffer.from(alice.id))
   t.true(
-    queryTree.data[1].data[0].data.seek.toString().includes('bipf.seekKey')
+    queryTree.data[1].data[0].data.seek.toString().includes('compiledSeek')
   )
 
   t.equal(queryTree.data[1].data[1].type, 'EQUAL')
   t.equal(queryTree.data[1].data[1].data.indexType, 'value_author')
   t.deepEqual(queryTree.data[1].data[1].data.value, Buffer.from(bob.id))
   t.true(
-    queryTree.data[1].data[1].data.seek.toString().includes('bipf.seekKey')
+    queryTree.data[1].data[1].data.seek.toString().includes('compiledSeek')
   )
 
   t.end()


### PR DESCRIPTION
This PR improves the speed of `slowEqual` by using [`bipf.createSeekPath`](https://github.com/ssbc/bipf/blob/master/index.js#L313) as suggested in #128.

## Before
  
  | Part | Speed | Heap Change | Samples |
  |---|---|---|---|
  | Query 1 big index with slowEqual (1st run) | 906.45ms ± 16.61ms | -851.7 kB ± 41.62 kB | 5 |
  | Query 1 big index with slowEqual (2nd run) | 245.64ms ± 7.76ms | -697.62 kB ± 38.45 kB | 5 |
  | Query 1 big index with slowEqual (3rd run) | 0.31ms ± 0.15ms | 38.13 kB ± 0 kB | 5 |


## After
  
  | Part | Speed | Heap Change | Samples |
  |---|---|---|---|
  | Query 1 big index with slowEqual (1st run) | 866.11ms ± 35ms | 1.07 MB ± 0 MB | 5 |
  | Query 1 big index with slowEqual (2nd run) | 296.57ms ± 4.96ms | 528.21 kB ± 0 kB | 5 |
  | Query 1 big index with slowEqual (3rd run) | 0.27ms ± 0.02ms | -85.7 kB ± 0 kB | 5 |