### PR TITLE
Configure benchmarks to run in parallel

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -59,7 +59,7 @@ jobs:
           cache-name: cache-benchmark-fixture
         with:
           path: /tmp/jitdb-benchmark
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json','**/package.json','**/benchmark/**/*.js') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json','**/package.json','**/benchmark/**/*.js','**/.github/**/*') }}
       - name: Generate Benchmark Fixture
         if: steps.benchmark-fixture-cache.outputs.cache-hit != 'true'
         run: npm run benchmark-only-create

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,8 +28,7 @@ jobs:
       - name: npm test
         run: DEBUG=jitdb npm test
 
-  find_benchmark_jobs:
-    needs: test
+  prepare_for_benchmarks:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -53,8 +52,18 @@ jobs:
             echo $BENCHMARKS
             echo "::set-output name=matrix::{\"benchmark\":$BENCHMARKS}"
           fi
+      - name: Restore Benchmark Fixture Cache
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-benchmark-fixture
+        with:
+          path: /tmp/jitdb-benchmark
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json','**/package.json','**/benchmark/**/*.js') }}
       - name: Generate Benchmark Fixture
-        run: npm run benchmark-only-create
+        run: |
+          if [ ! -d /tmp/jitdb-benchmark ]; then
+            npm run benchmark-only-create
+          fi
       - name: Upload Benchmark Fixture
         uses: actions/upload-artifact@v2
         with:
@@ -63,11 +72,13 @@ jobs:
           retention-days: 1
 
   benchmark:
-    needs: find_benchmark_jobs
+    needs:
+      - test
+      - prepare_for_benchmarks
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.find_benchmark_jobs.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.prepare_for_benchmarks.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -53,6 +53,14 @@ jobs:
             echo $BENCHMARKS
             echo "::set-output name=matrix::{\"benchmark\":$BENCHMARKS}"
           fi
+      - name: Generate Benchmark Fixture
+        run: npm run benchmark-only-create
+      - name: Upload Benchmark Fixture
+        uses: actions/upload-artifact@v2
+        with:
+          name: benchmark-fixture
+          path: /tmp/jitdb-benchmark
+          retention-days: 1
 
   benchmark:
     needs: find_benchmark_jobs
@@ -68,6 +76,11 @@ jobs:
         with:
           node-version: 12.x
       - run: npm install
+      - name: Download Benchmark Fixture
+        uses: actions/download-artifact@v2
+        with:
+          name: benchmark-fixture
+          path: /tmp/jitdb-benchmark
       - name: Benchmark
         run: CURRENT_BENCHMARK="${{matrix.benchmark}}" npm run benchmark
       - name: Upload Result

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -92,7 +92,7 @@ jobs:
           name: benchmark-fixture
           path: /tmp/jitdb-benchmark
       - name: Benchmark
-        run: CURRENT_BENCHMARK="${{matrix.benchmark}}" npm run benchmark
+        run: BENCHMARK_DURATION_MS=60000 CURRENT_BENCHMARK="${{matrix.benchmark}}" npm run benchmark
       - name: Upload Result
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -115,7 +115,7 @@ jobs:
           headLineCount=$(printf "$body" | grep -hn '\--' | cut -f1 -d:)
           totalLineCount=$(printf "$body" | wc -l | cut -f1 -d" ")
           headLines=$(printf "$body" | head -n $headLineCount)
-          sortedTailLines=$(printf "$body" | tail -n $(($totalLineCount - $headLineCount)))
+          sortedTailLines=$(printf "$body" | tail -n $(($totalLineCount - $headLineCount + 1)) | sort)
           body=$(printf "$headLines\n$sortedTailLines")
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -100,7 +100,7 @@ jobs:
           path: /tmp/jitdb-benchmark/benchmark.md
           retention-days: 1
 
-  benchmark-results:
+  benchmark_results:
     needs: benchmark
     runs-on: ubuntu-latest
     steps:
@@ -112,6 +112,11 @@ jobs:
         name: Gather results
         run: |
           body=$(cat /tmp/artifacts/*-md/* | awk '!x[$0]++')
+          headLineCount=$(printf "$body" | grep -hn '\--' | cut -f1 -d:)
+          totalLineCount=$(printf "$body" | wc -l | cut -f1 -d" ")
+          headLines=$(printf "$body" | head -n $headLineCount)
+          sortedTailLines=$(printf "$body" | tail -n $(($totalLineCount - $headLineCount)))
+          body=$(printf "$headLines\n$sortedTailLines")
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -53,6 +53,7 @@ jobs:
             echo "::set-output name=matrix::{\"benchmark\":$BENCHMARKS}"
           fi
       - name: Restore Benchmark Fixture Cache
+        id: benchmark-fixture-cache
         uses: actions/cache@v2
         env:
           cache-name: cache-benchmark-fixture
@@ -60,10 +61,8 @@ jobs:
           path: /tmp/jitdb-benchmark
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json','**/package.json','**/benchmark/**/*.js') }}
       - name: Generate Benchmark Fixture
-        run: |
-          if [ ! -d /tmp/jitdb-benchmark ]; then
-            npm run benchmark-only-create
-          fi
+        if: steps.benchmark-fixture-cache.outputs.cache-hit != 'true'
+        run: npm run benchmark-only-create
       - name: Upload Benchmark Fixture
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Upload Result
         uses: actions/upload-artifact@v2
         with:
-          name: ${{matrix.benchmark}}.md
+          name: ${{matrix.benchmark}}-md
           path: /tmp/jitdb-benchmark/benchmark.md
           retention-days: 1
 
@@ -101,7 +101,7 @@ jobs:
       - id: get-comment-body
         name: Gather results
         run: |
-          body=$(cat /tmp/artifacts/*.md | awk '!x[$0]++')
+          body=$(cat /tmp/artifacts/*-md/* | awk '!x[$0]++')
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,10 +28,38 @@ jobs:
       - name: npm test
         run: DEBUG=jitdb npm test
 
-  benchmark:
+  find_benchmark_jobs:
     needs: test
-
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - run: npm install
+      - id: set-matrix
+        run: |
+          echo "getting benchmark matrix"
+          BENCHMARKS=$(npm run --silent get-benchmark-matrix)
+          echo "checking benchmark matrix"
+          if [ -z "$BENCHMARKS" ]; then
+            echo "Failed to generate benchmarks"
+            exit 1
+          else
+            echo $BENCHMARKS
+            echo "::set-output name=matrix::{\"benchmark\":$BENCHMARKS}"
+          fi
+
+  benchmark:
+    needs: find_benchmark_jobs
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.find_benchmark_jobs.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v2
@@ -41,11 +69,26 @@ jobs:
           node-version: 12.x
       - run: npm install
       - name: Benchmark
-        run: npm run benchmark
+        run: CURRENT_BENCHMARK="${{matrix.benchmark}}" npm run benchmark
+      - name: Upload Result
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{matrix.benchmark}}.md
+          path: /tmp/jitdb-benchmark/benchmark.md
+          retention-days: 1
+
+  benchmark-results:
+    needs: benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Results
+        uses: actions/download-artifact@v2
+        with:
+          path: /tmp/artifacts
       - id: get-comment-body
         name: Gather results
         run: |
-          body=$(cat /tmp/jitdb-benchmark/benchmark.md)
+          body=$(cat /tmp/artifacts/*.md | awk '!x[$0]++')
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"

--- a/benchmark/helpers/run_benchmark.js
+++ b/benchmark/helpers/run_benchmark.js
@@ -76,7 +76,8 @@ function runBenchmark(benchmarkName, benchmarkFn, setupFn, callback) {
             }
           })
         })
-      }
+      },
+      Number(process.env.BENCHMARK_DURATION_MS || 3000)
     ).then(result => {
       callback(null, getTestStats(benchmarkName, result))
     }).catch(e => {

--- a/benchmark/helpers/setup_test_functions.js
+++ b/benchmark/helpers/setup_test_functions.js
@@ -1,44 +1,46 @@
-const tape = require('tape');
+const tape = require('tape')
 
-const skipCreate = process.argv[2] === 'noCreate' || !!process.env.GET_BENCHMARK_MATRIX || !!process.env.CURRENT_BENCHMARK;
-exports.skipCreate = skipCreate;
-const testList = [];
+const skipCreate =
+  process.argv[2] === 'noCreate' ||
+  !!process.env.GET_BENCHMARK_MATRIX ||
+  !!process.env.CURRENT_BENCHMARK
+exports.skipCreate = skipCreate
+const testList = []
 if (process.env.GET_BENCHMARK_MATRIX) {
   process.on('exit', ({ exit }) => {
-    console.log(JSON.stringify(testList));
-    if (exit)
-      process.exit();
-  });
+    console.log(JSON.stringify(testList))
+    if (exit) process.exit()
+  })
 }
 const fixture = (name, ...args) => {
   if (process.env.GET_BENCHMARK_MATRIX) {
-    return;
+    return
   } else if (process.env.FIXTURES_ONLY) {
-    tape(name, ...args);
+    tape(name, ...args)
   } else if (process.env.CURRENT_BENCHMARK) {
     tape(name, (t) => {
-      t.skip();
-      t.end();
-    });
+      t.skip()
+      t.end()
+    })
   }
-};
-exports.fixture = fixture;
+}
+exports.fixture = fixture
 const test = (name, ...args) => {
   if (process.env.GET_BENCHMARK_MATRIX) {
-    testList.push(name);
+    testList.push(name)
   } else if (process.env.FIXTURES_ONLY) {
     tape(name, (t) => {
-      t.skip();
-      t.end();
-    });
+      t.skip()
+      t.end()
+    })
   } else if (process.env.CURRENT_BENCHMARK) {
     if (name.startsWith(process.env.CURRENT_BENCHMARK)) {
-      tape.only(name, ...args);
+      tape.only(name, ...args)
     } else {
-      tape(name, ...args);
+      tape(name, ...args)
     }
   } else {
-    tape(name, ...args);
+    tape(name, ...args)
   }
-};
-exports.test = test;
+}
+exports.test = test

--- a/benchmark/helpers/setup_test_functions.js
+++ b/benchmark/helpers/setup_test_functions.js
@@ -1,0 +1,44 @@
+const tape = require('tape');
+
+const skipCreate = process.argv[2] === 'noCreate' || !!process.env.GET_BENCHMARK_MATRIX || !!process.env.CURRENT_BENCHMARK;
+exports.skipCreate = skipCreate;
+const testList = [];
+if (process.env.GET_BENCHMARK_MATRIX) {
+  process.on('exit', ({ exit }) => {
+    console.log(JSON.stringify(testList));
+    if (exit)
+      process.exit();
+  });
+}
+const fixture = (name, ...args) => {
+  if (process.env.GET_BENCHMARK_MATRIX) {
+    return;
+  } else if (process.env.FIXTURES_ONLY) {
+    tape(name, ...args);
+  } else if (process.env.CURRENT_BENCHMARK) {
+    tape(name, (t) => {
+      t.skip();
+      t.end();
+    });
+  }
+};
+exports.fixture = fixture;
+const test = (name, ...args) => {
+  if (process.env.GET_BENCHMARK_MATRIX) {
+    testList.push(name);
+  } else if (process.env.FIXTURES_ONLY) {
+    tape(name, (t) => {
+      t.skip();
+      t.end();
+    });
+  } else if (process.env.CURRENT_BENCHMARK) {
+    if (name.startsWith(process.env.CURRENT_BENCHMARK)) {
+      tape.only(name, ...args);
+    } else {
+      tape(name, ...args);
+    }
+  } else {
+    tape(name, ...args);
+  }
+};
+exports.test = test;

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,4 +1,3 @@
-const tape = require('tape')
 const fs = require('fs')
 const path = require('path')
 const pull = require('pull-stream')
@@ -26,33 +25,13 @@ const {
 } = require('../operators')
 const { seekType, seekAuthor, seekVoteLink } = require('../test/helpers')
 const copy = require('../copy-json-to-bipf-async')
+const { skipCreate, fixture, test } = require("./helpers/setup_test_functions")
 
 const dir = '/tmp/jitdb-benchmark'
 const oldLogPath = path.join(dir, 'flume', 'log.offset')
 const newLogPath = path.join(dir, 'flume', 'log.bipf')
 const reportPath = path.join(dir, 'benchmark.md')
 const indexesDir = path.join(dir, 'indexes')
-
-const skipCreate = process.argv[2] === 'noCreate' || !!process.env.GET_BENCHMARK_MATRIX
-const testList = []
-process.on('exit', ({ exit }) => {
-  console.log(JSON.stringify(testList))
-  if (exit) process.exit()
-})
-const test = (name, ...args) => {
-  if (process.env.GET_BENCHMARK_MATRIX) {
-    testList.push(name)
-  } else if (process.env.CURRENT_BENCHMARK) {
-    if (name.startsWith(process.env.CURRENT_BENCHMARK)) {
-      tape.only(name, ...args)
-    } else {
-      tape(name, ...args)
-    }
-  } else {
-      tape(name, ...args)
-  }
-}
-
 
 /**
  * Wait for a file to exist and for writes to that file
@@ -101,7 +80,7 @@ if (!skipCreate) {
   const MESSAGES = 100000
   const AUTHORS = 2000
 
-  tape('generate fixture with flumelog-offset', (t) => {
+  fixture('generate fixture with flumelog-offset', (t) => {
     generateFixture({
       outputDir: dir,
       seed: SEED,
@@ -121,7 +100,7 @@ if (!skipCreate) {
     })
   })
 
-  tape('move flumelog-offset to async-log', (t) => {
+  fixture('move flumelog-offset to async-log', (t) => {
     copy(oldLogPath, newLogPath, (err) => {
       if (err) {
         t.fail(err)

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "format-code-staged": "pretty-quick --staged --pattern \"*.js\" --pattern \"test/*.js\"",
     "benchmark": "node benchmark/index.js | tap-spec",
     "benchmark-no-create": "node benchmark/index.js noCreate | tap-spec",
-    "get-benchmark-matrix": "GET_BENCHMARK_MATRIX=1 node benchmark/index.js"
+    "get-benchmark-matrix": "GET_BENCHMARK_MATRIX=1 node benchmark/index.js",
+    "benchmark-only-create": "FIXTURES_ONLY=1 node benchmark/index.js"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "format-code": "prettier --write \"*.js\" \"test/*.js\"",
     "format-code-staged": "pretty-quick --staged --pattern \"*.js\" --pattern \"test/*.js\"",
     "benchmark": "node benchmark/index.js | tap-spec",
-    "benchmark-no-create": "node benchmark/index.js noCreate | tap-spec"
+    "benchmark-no-create": "node benchmark/index.js noCreate | tap-spec",
+    "get-benchmark-matrix": "GET_BENCHMARK_MATRIX=1 node benchmark/index.js"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This PR updates the Github workflows to run the benchmarks in parallel. It also caches the fixture portion of the benchmark which is already excluded from the results. You can find this generated markdown in [the benchmark-results job](https://github.com/ssb-ngi-pointer/jitdb/runs/2315730948), which will list the results in alphabetical order.

I expect that running the benchmarks this way will significantly reduce the chance of benchmarks affecting one anothers' performance. Additionally, we can capitalize on the time between the fastest and slowest benchmarks to gather more samples without extending the pipeline runtime.

## Benchmark results
  
  | Part | Speed | Heap Change | Samples |
  |---|---|---|---|
  | Count 1 big index (3rd run) | 0.33ms ± 0.11ms | 12.82 kB ± 0 kB | 46 |
  | Create an index twice concurrently | 922.31ms ± 10.88ms | -25.03 kB ± 0 kB | 59 |
  | Load core indexes | 0.87ms ± 0.01ms | 84 B ± 15060 B | 8775 |
  | Load two indexes concurrently | 1499.47ms ± 16.7ms | 36.39 kB ± 12.99 kB | 12 |
  | Paginate 10 results | 17.54ms ± 1.97ms | 7.11 kB ± 45.51 kB | 26 |
  | Paginate 20000 msgs with pageSize=5 | 6385.62ms ± 78.38ms | 810.46 kB ± 35.42 kB | 5 |
  | Paginate 20000 msgs with pageSize=500 | 663.1ms ± 23.89ms | 546.36 kB ± 27.92 kB | 18 |
  | Query 1 big index (1st run) | 857.01ms ± 13.82ms | 32.84 kB ± 0 kB | 63 |
  | Query 1 big index (2nd run) | 249.16ms ± 2.94ms | 56.12 kB ± 0 kB | 54 |
  | Query 3 indexes (1st run) | 931.37ms ± 30.2ms | 42.96 kB ± 43.3 kB | 59 |
  | Query 3 indexes (2nd run) | 251.3ms ± 2.04ms | 7 kB ± 0 kB | 45 |
  | Query a prefix map (1st run) | 297.8ms ± 5.15ms | 19.88 kB ± 15.44 kB | 21 |
  | Query a prefix map (2nd run) | 9.47ms ± 0.66ms | 1 kB ± 0 kB | 24 |