### PR TITLE
Refactor executeOperation()

### DIFF
--- a/index.js
+++ b/index.js
@@ -987,22 +987,18 @@ module.exports = function (log, indexesPath) {
 
       // Load lazy indexes, if any
       push.asyncMap((_, next) => {
-        if (lazyIdxNames.length === 0) next()
-        else {
-          push(
-            push.values(lazyIdxNames),
-            push.asyncMap(loadLazyIndex),
-            push.collect(next)
-          )
-        }
+        if (lazyIdxNames.length === 0) return next()
+        push(
+          push.values(lazyIdxNames),
+          push.asyncMap(loadLazyIndex),
+          push.collect(next)
+        )
       }),
 
       // Create missing indexes, if any
       push.asyncMap((_, next) => {
-        if (opsMissingIdx.length === 0) next()
-        else {
-          createIndexes(opsMissingIdx, next)
-        }
+        if (opsMissingIdx.length === 0) return next()
+        createIndexes(opsMissingIdx, next)
       }),
 
       // Get bitset for the input operation, and cache it

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "push-stream": "^11.0.0",
     "push-stream-to-pull-stream": "^1.0.3",
     "sanitize-filename": "^1.6.3",
+    "tap-bail": "^1.0.0",
     "traverse": "^0.6.6",
     "typedarray-to-buffer": "^4.0.0",
     "typedfastbitset": "~0.2.1"
@@ -50,7 +51,7 @@
     "tape": "^5.2.2"
   },
   "scripts": {
-    "test": "tape test/*.js | tap-spec",
+    "test": "tape test/*.js | tap-bail | tap-spec",
     "format-code": "prettier --write \"*.js\" \"test/*.js\"",
     "format-code-staged": "pretty-quick --staged --pattern \"*.js\" --pattern \"test/*.js\"",
     "benchmark": "node benchmark/index.js | tap-spec",


### PR DESCRIPTION
This was just a warm-up before I refactor `ensureEnoughResults` and others.

With this PR I wanted to make the asynchronous execution order match the "reading order" from top to bottom. `executeOperation` had a lot of jumping around in that regard.