### PR TITLE
Preprocess the conversion of strings to buffers for slowEquals and use LRU cache

### DIFF
--- a/operators.js
+++ b/operators.js
@@ -1,5 +1,4 @@
 const bipf = require('bipf')
-const LRU = require('lru-cache')
 const traverse = require('traverse')
 const promisify = require('promisify-4loc')
 const pull = require('pull-stream')
@@ -32,12 +31,10 @@ function toBufferOrFalsy(value) {
   return Buffer.isBuffer(value) ? value : Buffer.from(value)
 }
 
-const slowEqualsCache = new LRU({
-  max: 1500,
-})
+const seekFromDescCache = new Map()
 function seekFromDesc(desc) {
-  if (slowEqualsCache.has(desc)) {
-    return slowEqualsCache.get(desc)
+  if (seekFromDescCache.has(desc)) {
+    return seekFromDescCache.get(desc)
   }
   const keys = desc.split('.').map(Buffer.from)
   // The 2nd arg `start` is to support plucks too
@@ -49,7 +46,7 @@ function seekFromDesc(desc) {
     }
     return p
   }
-  slowEqualsCache.set(desc, fn)
+  seekFromDescCache.set(desc, fn)
   return fn
 }
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "fastpriorityqueue": "^0.7.1",
     "idb-kv-store": "^4.5.0",
     "jsesc": "^3.0.2",
-    "lru-cache": "^6.0.0",
     "mkdirp": "^1.0.4",
     "multicb": "1.2.2",
     "obz": "~1.0.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "fastpriorityqueue": "^0.7.1",
     "idb-kv-store": "^4.5.0",
     "jsesc": "^3.0.2",
+    "lru-cache": "^6.0.0",
     "mkdirp": "^1.0.4",
     "multicb": "1.2.2",
     "obz": "~1.0.3",


### PR DESCRIPTION
This MR includes only the performance enhancement, but you can reference https://github.com/Barbarrosa/jitdb/pull/18 which tests this using the (not yet merged) `slowEquals` benchmark.