### PR TITLE
Benchmark bugfixes

### DIFF
--- a/benchmark/helpers/setup_test_functions.js
+++ b/benchmark/helpers/setup_test_functions.js
@@ -22,6 +22,8 @@ const fixture = (name, ...args) => {
       t.skip()
       t.end()
     })
+  } else {
+    tape(name, ...args)
   }
 }
 exports.fixture = fixture


### PR DESCRIPTION
I noticed several issues with my prior benchmark changes.
- The ability to run the full benchmark beginning-to-end with a single command was broken.
- The right side of the heap result was based on standard deviation, not margin of error.

This PR fixes the first issue and switches the right side of the heap result to use a calculation method more similar to [what nodemark itself uses](https://github.com/JoshuaWise/nodemark/blob/master/lib/result.js#L14), i.e. based on margin of error.