### PR TITLE
Change "if" to "else if" to prevent unnecessary index generation

### DIFF
--- a/index.js
+++ b/index.js
@@ -610,7 +610,7 @@ module.exports = function (log, indexesPath) {
               seq,
               offset
             )
-          if (op.data.prefix)
+          else if (op.data.prefix)
             updatePrefixIndex(
               op.data,
               newIndexes[op.data.indexName],


### PR DESCRIPTION
Based on the documentation, it seems like the call here to `updatePrefixIndex` shouldn't occur when `useMap` is set.

> An additional option `useMap` can be provided that will store the prefix as a map instead of an array. The map can be seen as an inverted index that allows for faster queries at the cost of extra space. Maps don't store empty values meaning they are also a good fit for sparce indexes such as vote links.