### PR TITLE
Drop Node 10, add Node 16

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Node.js 10 is no longer an LTS version, but Node.js 16 is.