### PR TITLE
fix Buffer.from usage in operators.js

### DIFF
--- a/operators.js
+++ b/operators.js
@@ -36,7 +36,7 @@ function seekFromDesc(desc) {
   if (seekFromDescCache.has(desc)) {
     return seekFromDescCache.get(desc)
   }
-  const keys = desc.split('.').map(Buffer.from)
+  const keys = desc.split('.').map((str) => Buffer.from(str))
   // The 2nd arg `start` is to support plucks too
   const fn = function (buffer, start = 0) {
     var p = start


### PR DESCRIPTION
Just stumbled upon this dangerous use of `Buffer.from`. 

Basically `arr.map(Buffer.from)` is equivalent to `arr.map((str, index, array) => Buffer.from(str, index, array))` which is not what we intended to do. Gladly, calling Buffer.from with those 3 args **still** yields the correct result. But we're just lucky. This PR changes the usage so that it obviously does not pass the 3 args.