### PR TITLE
deferred() to support cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,11 +321,12 @@ deferred(task)
 where `task` is any function of the format
 
 ```js
-function task(meta, cb)
+function task(meta, cb[, onAbort])
 ```
 
 where `meta` is an object containing an instance of JITDB and other
-metadata.
+metadata, and `onAbort` is an optional function that you can pass an
+abort listener (i.e. `onAbort(() => { /* cancel my stuff */ })`).
 
 As an example, suppose you have a custom index that returns seqs
 `11`, `13` and `17`, and you want to include these results into your

--- a/test/operators.js
+++ b/test/operators.js
@@ -1063,9 +1063,7 @@ prepareAndRunTest('support cancelling deferred', dir, (t, db, raf) => {
                 }, 100)
 
                 let timer = setTimeout(() => {
-                  timer = null
                   t.fail('this should have been cancelled')
-                  cb(null, slowEqual('value.author', bob.id))
                 }, 200)
 
                 setTimeout(() => {

--- a/test/operators.js
+++ b/test/operators.js
@@ -1040,6 +1040,58 @@ prepareAndRunTest('support deferred operations or', dir, (t, db, raf) => {
   })
 })
 
+prepareAndRunTest('support cancelling deferred', dir, (t, db, raf) => {
+  const msg = { type: 'post', text: 'Testing!' }
+  let state = validate.initial()
+  state = validate.appendNew(state, null, alice, msg, Date.now())
+  state = validate.appendNew(state, null, bob, msg, Date.now() + 1)
+
+  addMsg(state.queue[0].value, raf, (e1, msg1) => {
+    addMsg(state.queue[1].value, raf, (e2, msg2) => {
+      let drainer
+      pull(
+        query(
+          fromDB(db),
+          where(
+            or(
+              slowEqual('value.author', alice.id),
+              deferred((meta, cb, onAbort) => {
+                setTimeout(() => {
+                  if (!drainer) t.fail('expected drain to have started')
+                  drainer.abort()
+                  t.pass('trigger abort')
+                }, 100)
+
+                let timer = setTimeout(() => {
+                  timer = null
+                  t.fail('this should have been cancelled')
+                  cb(null, slowEqual('value.author', bob.id))
+                }, 200)
+
+                setTimeout(() => {
+                  t.pass('task was successfully cancelled')
+                  t.end()
+                }, 400)
+
+                onAbort(() => {
+                  if (timer) {
+                    clearTimeout(timer)
+                    timer = null
+                  }
+                })
+              })
+            )
+          ),
+          toPullStream()
+        ),
+        (drainer = pull.drain((msg) => {
+          t.fail('should not drain yet')
+        }))
+      )
+    })
+  })
+})
+
 prepareAndRunTest('support empty deferred operations', dir, (t, db, raf) => {
   const msg = { type: 'post', text: 'Testing!' }
   let state = validate.initial()


### PR DESCRIPTION
For issue #163 

This gave me a bit of headache to write, so I don't expect it to be a simple PR to review, but it seems correct and I'm glad our test suite is thorough.

The basic idea is to replace Promises in `executeDeferredOps` with pull-streams and `multicb`, because pull-streams support cancellation and it seems like a natural choice of async mechanism for our repo. The pull-stream `readable` replaces the `async-await` and `multicb` replaces the `Promise.all`.

When the readable is aborted (called with 1st arg `true`), then we call all the abort listeners.