### PR TITLE
add .npmignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "type": "git",
     "url": "git://github.com/ssb-ngi-pointer/jitdb.git"
   },
+  "files": [
+    "*.js",
+    "!example.js"
+  ],
   "dependencies": {
     "atomic-file-rw": "^0.2.1",
     "binary-search-bounds": "^2.0.4",


### PR DESCRIPTION
To slim down the size of the package.

## Before

```
npm notice 
npm notice 📦  jitdb@3.1.7
npm notice === Tarball Contents ===                                
npm notice 42B    .prettierrc                              
npm notice 7.7kB  LICENSE                                  
npm notice 2.3kB  flumelog.diff                            
npm notice 11.5kB test/add.js                              
npm notice 1.2kB  test/common.js                           
npm notice 1.4kB  copy-json-to-bipf-async.js               
npm notice 780B   copy-json-to-bipf-offset.js              
npm notice 1.1kB  copy-json-to-bipf.js                     
npm notice 1.6kB  test/del.js                              
npm notice 7.3kB  example.js                               
npm notice 4.9kB  files.js                                 
npm notice 2.4kB  test/helpers.js                          
npm notice 17.2kB benchmark/index.js                       
npm notice 41.5kB index.js                                 
npm notice 1.3kB  test/live-then-grow.js                   
npm notice 9.3kB  test/live.js                             
npm notice 11.2kB operators.js                             
npm notice 40.4kB test/operators.js                        
npm notice 15.6kB test/prefix.js                           
npm notice 26.2kB test/query.js                            
npm notice 2.6kB  benchmark/helpers/run_benchmark.js       
npm notice 5.2kB  test/save-load.js                        
npm notice 1.8kB  test/seq-index-not-uptodate.js           
npm notice 1.1kB  benchmark/helpers/setup_test_functions.js
npm notice 3.3kB  test/slow-save.js                        
npm notice 1.3kB  status.js                                
npm notice 2.3kB  package.json                             
npm notice 16.1kB README.md                                
npm notice 892B   bench.txt                                
npm notice 4.2kB  .github/workflows/node.js.yml            
npm notice === Tarball Details === 
npm notice name:          jitdb                                   
npm notice version:       3.1.7                                   
npm notice filename:      jitdb-3.1.7.tgz                         
npm notice package size:  42.7 kB                                 
npm notice unpacked size: 243.8 kB                                
npm notice shasum:        1b2e3f8be2add70c2b4454c02282ee0608a2e169
npm notice integrity:     sha512-Atc22WTEBwGJ7[...]a3IjyvThULntg==
npm notice total files:   30                              
npm notice 
jitdb-3.1.7.tgz
```

## After

```
npm notice 
npm notice 📦  jitdb@3.1.7
npm notice === Tarball Contents === 
npm notice 7.7kB  LICENSE                    
npm notice 1.4kB  copy-json-to-bipf-async.js 
npm notice 780B   copy-json-to-bipf-offset.js
npm notice 1.1kB  copy-json-to-bipf.js       
npm notice 4.9kB  files.js                   
npm notice 41.5kB index.js                   
npm notice 11.2kB operators.js               
npm notice 1.3kB  status.js                  
npm notice 2.3kB  package.json               
npm notice 16.1kB README.md                  
npm notice === Tarball Details === 
npm notice name:          jitdb                                   
npm notice version:       3.1.7                                   
npm notice filename:      jitdb-3.1.7.tgz                         
npm notice package size:  22.3 kB                                 
npm notice unpacked size: 88.1 kB                                 
npm notice shasum:        4d118d4b8d00d85ea6d0b0cc313faaa0c5e52904
npm notice integrity:     sha512-RxINKI2NBWMfu[...]gkklIF87oJj6g==
npm notice total files:   10                                      
npm notice 
jitdb-3.1.7.tgz
```