### PR TITLE
add operator batch()

### DIFF
--- a/test/operators.js
+++ b/test/operators.js
@@ -26,6 +26,7 @@ const {
   offsets,
   fromDB,
   paginate,
+  batch,
   startFrom,
   live,
   count,
@@ -1257,6 +1258,7 @@ prepareAndRunTest('support live operations', dir, (t, db, raf) => {
       fromDB(db),
       where(slowEqual('value.content.type', 'post')),
       live({ old: true }),
+      batch(2),
       toPullStream(),
       pull.drain((msg) => {
         if (i++ == 0) {


### PR DESCRIPTION
For issue #167 

Achieved in a non-breaking manner, `paginate()` remains as it is, causing the final pull-stream to emit arrays of messages. We introduce `batch()` that has the same performance profile as `paginate()`, but just configure how the results should be streamed: one message at a time, no array of messages.