### PR TITLE
add operator predicate()

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,15 @@ desired set of messages: `and`, `or`, `not`, `equal`, `slowEqual`, and others.
   - `objPath` a string in the shape `"foo.bar.baz"` which specifies the nested field `"baz"` inside `"bar"` inside `"foo"`
   - `value` is the same as `value` in the `equal` operator
   - `opts` same as the opts for `equal()`
-- `includes(seek, value, opts)` filters for messages where a `seek`ed` _field_
+- `includes(seek, value, opts)` filters for messages where a `seek`ed _field_
   is an array and includes a specific _value_
 - `slowIncludes(objPath, value, opts)` is to `includes` what `slowEqual` is to
   `equal`
 - `predicate(seek, fn, opts)` filters for messages where a `seek`ed _field_ is
   passed to a predicate function `fn` and the `fn` returns true
+  - `opts` are additional configurations such as `indexType` and `name`. You
+  SHOULD pass `opts.name` as a simple string uniquely identifying the predicate,
+  OR the `fn` function should be a named function
 - `slowPredicate(objPath, fn, opts)` is to `predicate` what `slowEqual` is to
   `equal`
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ desired set of messages: `and`, `or`, `not`, `equal`, `slowEqual`, and others.
 - `and(...args)` filters for messages that satisfy **all** `args`
 - `or(...args)` filters for messages that satisfy **at least one** of the `args`
 - `not(arg)` filters for messages that do not safisfy `arg`
-- `equal(seek, value, opts)` filters for messages where a specific _field_ matches a specific _value_:
+- `equal(seek, value, opts)` filters for messages where a `seek`ed _field_
+  matches a specific _value_:
   - `seek` is a function that takes a [bipf] buffer as input and uses
     `bipf.seekKey` to return a pointer to the _field_
   - `value` is a string or buffer which is the value we want the _field_'s value to match
@@ -102,6 +103,14 @@ desired set of messages: `and`, `or`, `not`, `equal`, `slowEqual`, and others.
   - `objPath` a string in the shape `"foo.bar.baz"` which specifies the nested field `"baz"` inside `"bar"` inside `"foo"`
   - `value` is the same as `value` in the `equal` operator
   - `opts` same as the opts for `equal()`
+- `includes(seek, value, opts)` filters for messages where a `seek`ed` _field_
+  is an array and includes a specific _value_
+- `slowIncludes(objPath, value, opts)` is to `includes` what `slowEqual` is to
+  `equal`
+- `predicate(seek, fn, opts)` filters for messages where a `seek`ed _field_ is
+  passed to a predicate function `fn` and the `fn` returns true
+- `slowPredicate(objPath, fn, opts)` is to `predicate` what `slowEqual` is to
+  `equal`
 
 Some examples:
 
@@ -391,6 +400,8 @@ const {
   not,
   equal,
   slowEqual,
+  predicate,
+  slowPredicate,
   includes,
   slowIncludes,
   gt,

--- a/operators.js
+++ b/operators.js
@@ -146,7 +146,7 @@ function slowPredicate(seekDesc, fn, opts) {
     throw new Error('predicate() needs a predicate function in the 2rd arg')
   const value = fn
   const indexType = seekDesc.replace(/\./g, '_')
-  const name = fn.name || opts.name
+  const name = opts.name || fn.name
   if (!name) throw new Error('predicate() needs opts.name')
   const indexName = safeFilename(indexType + '__pred_' + name)
   return {
@@ -168,7 +168,7 @@ function predicate(seek, fn, opts) {
     throw new Error('predicate() needs a predicate function in the 2rd arg')
   const value = fn
   const indexType = opts.indexType
-  const name = fn.name || opts.name
+  const name = opts.name || fn.name
   if (!name) throw new Error('predicate() needs opts.name')
   const indexName = safeFilename(indexType + '__pred_' + name)
   return {

--- a/operators.js
+++ b/operators.js
@@ -139,6 +139,49 @@ function equal(seek, target, opts) {
   }
 }
 
+function slowPredicate(seekDesc, fn, opts) {
+  opts = opts || {}
+  const seek = seekFromDesc(seekDesc)
+  if (typeof fn !== 'function')
+    throw new Error('predicate() needs a predicate function in the 2rd arg')
+  const value = fn
+  const indexType = seekDesc.replace(/\./g, '_')
+  const name = fn.name || opts.name
+  if (!name) throw new Error('predicate() needs opts.name')
+  const indexName = safeFilename(indexType + '__pred_' + name)
+  return {
+    type: 'PREDICATE',
+    data: {
+      seek,
+      value,
+      indexType,
+      indexName,
+    },
+  }
+}
+
+function predicate(seek, fn, opts) {
+  opts = opts || {}
+  if (!opts.indexType)
+    throw new Error('predicate() operator needs an indexType in the 3rd arg')
+  if (typeof fn !== 'function')
+    throw new Error('predicate() needs a predicate function in the 2rd arg')
+  const value = fn
+  const indexType = opts.indexType
+  const name = fn.name || opts.name
+  if (!name) throw new Error('predicate() needs opts.name')
+  const indexName = safeFilename(indexType + '__pred_' + name)
+  return {
+    type: 'PREDICATE',
+    data: {
+      seek,
+      value,
+      indexType,
+      indexName,
+    },
+  }
+}
+
 function slowIncludes(seekDesc, target, opts) {
   opts = opts || {}
   const seek = seekFromDesc(seekDesc)
@@ -495,6 +538,8 @@ module.exports = {
   live,
   slowEqual,
   equal,
+  slowPredicate,
+  predicate,
   slowIncludes,
   includes,
   where,

--- a/test/operators.js
+++ b/test/operators.js
@@ -1420,7 +1420,10 @@ prepareAndRunTest('support slowPredicate', dir, (t, db, raf) => {
       addMsg(state.queue[2].value, raf, (e3, m3) => {
         query(
           fromDB(db),
-          where(slowPredicate('value.content.animal', (x) => x.length === 3)),
+          where(
+            slowPredicate('value.content.animal', (x) => x.length === 3),
+            { name: '3char' }
+          ),
           toCallback((err, msgs) => {
             t.error(err, 'got no error')
             t.equal(msgs.length, 2, 'got two messages')

--- a/test/operators.js
+++ b/test/operators.js
@@ -1421,8 +1421,9 @@ prepareAndRunTest('support slowPredicate', dir, (t, db, raf) => {
         query(
           fromDB(db),
           where(
-            slowPredicate('value.content.animal', (x) => x.length === 3),
-            { name: '3char' }
+            slowPredicate('value.content.animal', (x) => x.length === 3, {
+              name: '3char',
+            })
           ),
           toCallback((err, msgs) => {
             t.error(err, 'got no error')


### PR DESCRIPTION
## Context

For ssb-meta-feeds, we're going to need to scan through all bendy butt messages and build an in-memory Map of subfeed IDs to their creation details (feedpurpose etc).

In order to scan through all bendy butt messages we need to do something like this

```js
ssb.db.query(
  where(valueAuthorIsBendyButtURI),
  toCallback(cb)
)
```

## Problem

I realize that we can't use `equal` because there are several bendybutt author URIs, not just one, and we can't use `includes` (because it's for arrays), we can't use what JITDB gives us. I would have to make a leveldb index, but it would still be a "bit vector"ish index, because all I need to know is a boolean, whether the given msg is authored by any bendybutt author URI or not.

## Solution

`predicate()` is a new operator in JITDB that allows you to pass it a boolean-returning function, similar to array.filter, e.g.

```js
slowPredicate('value.author', SSBURI.isBendyButtV1FeedSSBURI)
```

`predicate()` was pretty simple to implement because it's just a generalization of `equal()`.