### PR TITLE
Change the value of an operation to be a bipf value

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ desired set of messages: `and`, `or`, `not`, `equal`, `slowEqual`, and others.
   `equal`
 - `absent(seek, opts)` filters for messages where a `seek`ed _field_ does not
   exist in the message
-- `slowAbsent(objPath, opts)` is to `absent` what `slowEqual` is to `equal`
+- `slowAbsent(objPath)` is to `absent` what `slowEqual` is to `equal`
 
 Some examples:
 

--- a/README.md
+++ b/README.md
@@ -507,12 +507,13 @@ Operation can be of the following types:
 
 `seek` is a function that takes a buffer from the database as input
 and returns an index in the buffer from where a value can be compared
-to the `value` given. If value is `undefined` it corresponds to the
-field not being defined at that point in the buffer. `prefix` enables
-the use of prefix indexes for this operation. `indexType` is used to
-group indexes of the same type. If `indexAll` is specified and no
-index of the type and value exists, then instead of only this index
-being created, missing indexes for all possible values given the seek
+to the `value` given. `value` must be a bipf encoded value, usually
+the `equal` operator will take care of that. A field not being defined
+at a point in the buffer is equal to `undefined`. `prefix` enables the
+use of prefix indexes for this operation. `indexType` is used to group
+indexes of the same type. If `indexAll` is specified and no index of
+the type and value exists, then instead of only this index being
+created, missing indexes for all possible values given the seek
 pointer will be created. This can be particular useful for data where
 there number of different values are rather small, but still larger
 than a few. One example is author or feeds in SSB, a typical database

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ desired set of messages: `and`, `or`, `not`, `equal`, `slowEqual`, and others.
   OR the `fn` function should be a named function
 - `slowPredicate(objPath, fn, opts)` is to `predicate` what `slowEqual` is to
   `equal`
+- `absent(seek, opts)` filters for messages where a `seek`ed _field_ does not
+  exist in the message
+- `slowAbsent(objPath, opts)` is to `absent` what `slowEqual` is to `equal`
 
 Some examples:
 
@@ -411,6 +414,8 @@ const {
   slowEqual,
   predicate,
   slowPredicate,
+  absent,
+  slowAbsent,
   includes,
   slowIncludes,
   gt,

--- a/operators.js
+++ b/operators.js
@@ -41,7 +41,7 @@ function seekFromDesc(desc) {
     var p = start
     for (let key of keys) {
       p = bipf.seekKey(buffer, p, key)
-      if (!~p) return void 0
+      if (p < 0) return -1
     }
     return p
   }
@@ -175,6 +175,37 @@ function predicate(seek, fn, opts) {
     data: {
       seek,
       value,
+      indexType,
+      indexName,
+    },
+  }
+}
+
+function slowAbsent(seekDesc, opts) {
+  opts = opts || {}
+  const seek = seekFromDesc(seekDesc)
+  const indexType = seekDesc.replace(/\./g, '_')
+  const indexName = safeFilename(indexType + '__absent')
+  return {
+    type: 'ABSENT',
+    data: {
+      seek,
+      indexType,
+      indexName,
+    },
+  }
+}
+
+function absent(seek, opts) {
+  opts = opts || {}
+  if (!opts.indexType)
+    throw new Error('absent() operator needs an indexType in the 3rd arg')
+  const indexType = opts.indexType
+  const indexName = safeFilename(indexType + '__absent')
+  return {
+    type: 'ABSENT',
+    data: {
+      seek,
       indexType,
       indexName,
     },
@@ -539,6 +570,8 @@ module.exports = {
   equal,
   slowPredicate,
   predicate,
+  slowAbsent,
+  absent,
   slowIncludes,
   includes,
   where,

--- a/operators.js
+++ b/operators.js
@@ -30,11 +30,6 @@ function extractMeta(orig) {
   return meta
 }
 
-function toBufferOrFalsy(value) {
-  if (!value) return value
-  return Buffer.isBuffer(value) ? value : Buffer.from(value)
-}
-
 const seekFromDescCache = new Map()
 function seekFromDesc(desc) {
   if (seekFromDescCache.has(desc)) {
@@ -101,8 +96,8 @@ function debug() {
 function slowEqual(seekDesc, target, opts) {
   opts = opts || {}
   const seek = seekFromDesc(seekDesc)
-  const value = toBufferOrFalsy(target)
-  const valueName = !value ? '' : value.toString()
+  const value = bipf.allocAndEncode(target)
+  const valueName = !target ? '' : `${target}`
   const indexType = seekDesc.replace(/\./g, '_')
   const indexName = getIndexName(opts, indexType, valueName)
   return {
@@ -124,8 +119,8 @@ function equal(seek, target, opts) {
   opts = opts || {}
   if (!opts.indexType)
     throw new Error('equal() operator needs an indexType in the 3rd arg')
-  const value = toBufferOrFalsy(target)
-  const valueName = !value ? '' : value.toString()
+  const value = bipf.allocAndEncode(target)
+  const valueName = !target ? '' : `${target}`
   const indexType = opts.indexType
   const indexName = getIndexName(opts, indexType, valueName)
   return {
@@ -189,9 +184,9 @@ function predicate(seek, fn, opts) {
 function slowIncludes(seekDesc, target, opts) {
   opts = opts || {}
   const seek = seekFromDesc(seekDesc)
-  const value = toBufferOrFalsy(target)
+  const value = bipf.allocAndEncode(target)
   if (!value) throw new Error('slowIncludes() 2nd arg needs to be truthy')
-  const valueName = value.toString()
+  const valueName = !target ? '' : `${target}`
   const indexType = seekDesc.replace(/\./g, '_')
   const indexName = safeFilename(indexType + '_' + valueName)
   const pluck =
@@ -215,9 +210,9 @@ function includes(seek, target, opts) {
   opts = opts || {}
   if (!opts.indexType)
     throw new Error('includes() operator needs an indexType in the 3rd arg')
-  const value = toBufferOrFalsy(target)
+  const value = bipf.allocAndEncode(target)
   if (!value) throw new Error('includes() 2nd arg needs to be truthy')
-  const valueName = value.toString()
+  const valueName = !target ? '' : `${target}`
   const indexType = opts.indexType
   const indexName = safeFilename(indexType + '_' + valueName)
   return {

--- a/operators.js
+++ b/operators.js
@@ -181,8 +181,7 @@ function predicate(seek, fn, opts) {
   }
 }
 
-function slowAbsent(seekDesc, opts) {
-  opts = opts || {}
+function slowAbsent(seekDesc) {
   const seek = seekFromDesc(seekDesc)
   const indexType = seekDesc.replace(/\./g, '_')
   const indexName = safeFilename(indexType + '__absent')

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "atomic-file-rw": "^0.2.1",
     "binary-search-bounds": "^2.0.4",
-    "bipf": "^1.5.0",
+    "bipf": "^1.5.4",
     "crc": "3.6.0",
     "debug": "^4.2.0",
     "fastpriorityqueue": "^0.7.1",

--- a/test/add.js
+++ b/test/add.js
@@ -30,7 +30,7 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },
@@ -54,7 +54,7 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
               type: 'EQUAL',
               data: {
                 seek: helpers.seekAuthor,
-                value: Buffer.from(keys.id),
+                value: helpers.toBipf(keys.id),
                 indexType: 'author',
                 indexName: 'author_' + keys.id,
               },
@@ -97,7 +97,7 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
                           type: 'EQUAL',
                           data: {
                             seek: helpers.seekAuthor,
-                            value: Buffer.from(keys2.id),
+                            value: helpers.toBipf(keys2.id),
                             indexType: 'author',
                             indexName: 'author_' + keys2.id,
                           },
@@ -146,7 +146,7 @@ prepareAndRunTest('Update index', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },
@@ -187,7 +187,7 @@ prepareAndRunTest('obsolete status parts disappear', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },
@@ -214,7 +214,7 @@ prepareAndRunTest('obsolete status parts disappear', dir, (t, db, raf) => {
           type: 'EQUAL',
           data: {
             seek: helpers.seekType,
-            value: Buffer.from('about'),
+            value: helpers.toBipf('about'),
             indexType: 'type',
             indexName: 'type_about',
           },
@@ -253,7 +253,7 @@ prepareAndRunTest('grow', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },
@@ -292,7 +292,7 @@ prepareAndRunTest('indexAll', dir, (t, db, raf) => {
         type: 'EQUAL',
         data: {
           seek: helpers.seekType,
-          value: Buffer.from('post'),
+          value: helpers.toBipf('post'),
           indexType: 'type',
           indexName: 'type_post',
         },
@@ -301,7 +301,7 @@ prepareAndRunTest('indexAll', dir, (t, db, raf) => {
         type: 'EQUAL',
         data: {
           seek: helpers.seekAuthor,
-          value: Buffer.from(keys.id),
+          value: helpers.toBipf(keys.id),
           indexType: 'author',
           indexAll: true,
           indexName: safeFilename('author_' + keys.id),
@@ -343,7 +343,7 @@ prepareAndRunTest('indexAll multiple reindexes', dir, (t, db, raf) => {
       type: 'EQUAL',
       data: {
         seek: helpers.seekType,
-        value: Buffer.from(value),
+        value: helpers.toBipf(value),
         indexType: 'type',
         indexAll: true,
         indexName: safeFilename('type_' + value),

--- a/test/bump-version.js
+++ b/test/bump-version.js
@@ -33,7 +33,7 @@ prepareAndRunTest('Bitvector index version bumped', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },
@@ -49,7 +49,7 @@ prepareAndRunTest('Bitvector index version bumped', dir, (t, db, raf) => {
         type: 'EQUAL',
         data: {
           seek: helpers.seekType,
-          value: Buffer.from('post'),
+          value: helpers.toBipf('post'),
           indexType: 'type',
           indexName: 'type_post',
           version: 2,
@@ -75,7 +75,7 @@ prepareAndRunTest('Prefix map index version bumped', dir, (t, db, raf) => {
           type: 'EQUAL',
           data: {
             seek: helpers.seekKey,
-            value: Buffer.from(msgKey),
+            value: helpers.toBipf(msgKey),
             indexType: 'key',
             indexName: 'value_key',
             useMap: true,
@@ -92,7 +92,7 @@ prepareAndRunTest('Prefix map index version bumped', dir, (t, db, raf) => {
             type: 'EQUAL',
             data: {
               seek: helpers.seekKey,
-              value: Buffer.from(msgKey),
+              value: helpers.toBipf(msgKey),
               indexType: 'key',
               indexName: 'value_key',
               useMap: true,

--- a/test/del.js
+++ b/test/del.js
@@ -29,7 +29,7 @@ prepareAndRunTest('Delete', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -19,6 +19,10 @@ const B_PRIVATE = Buffer.from('private')
 const B_CHANNEL = Buffer.from('channel')
 
 module.exports = {
+  toBipf: function (value) {
+    return bipf.allocAndEncode(value)
+  },
+
   seekKey: function (buffer) {
     var p = 0 // note you pass in p!
     return bipf.seekKey(buffer, p, B_KEY)

--- a/test/live.js
+++ b/test/live.js
@@ -29,7 +29,7 @@ prepareAndRunTest('Live', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },
@@ -68,7 +68,7 @@ prepareAndRunTest('Live AND', dir, (t, db, raf) => {
         type: 'EQUAL',
         data: {
           seek: helpers.seekAuthor,
-          value: Buffer.from(keys.id),
+          value: helpers.toBipf(keys.id),
           indexType: 'author',
           indexName: 'author_' + keys.id,
         },
@@ -77,7 +77,7 @@ prepareAndRunTest('Live AND', dir, (t, db, raf) => {
         type: 'EQUAL',
         data: {
           seek: helpers.seekType,
-          value: Buffer.from('post'),
+          value: helpers.toBipf('post'),
           indexType: 'type',
           indexName: 'type_post',
         },
@@ -123,7 +123,7 @@ prepareAndRunTest('Live OR', dir, (t, db, raf) => {
         type: 'EQUAL',
         data: {
           seek: helpers.seekAuthor,
-          value: Buffer.from(keys.id),
+          value: helpers.toBipf(keys.id),
           indexType: 'author',
           indexName: 'author_' + keys.id,
         },
@@ -132,7 +132,7 @@ prepareAndRunTest('Live OR', dir, (t, db, raf) => {
         type: 'EQUAL',
         data: {
           seek: helpers.seekAuthor,
-          value: Buffer.from(keys2.id),
+          value: helpers.toBipf(keys2.id),
           indexType: 'author',
           indexName: 'author_' + keys2.id,
         },
@@ -148,7 +148,7 @@ prepareAndRunTest('Live OR', dir, (t, db, raf) => {
         type: 'EQUAL',
         data: {
           seek: helpers.seekType,
-          value: Buffer.from('post'),
+          value: helpers.toBipf('post'),
           indexType: 'type',
           indexName: 'type_post',
         },
@@ -197,7 +197,7 @@ prepareAndRunTest('Live GTE', dir, (t, db, raf) => {
         type: 'EQUAL',
         data: {
           seek: helpers.seekAuthor,
-          value: Buffer.from(keys.id),
+          value: helpers.toBipf(keys.id),
           indexType: 'author',
           indexName: 'author_' + keys.id,
         },
@@ -244,7 +244,7 @@ prepareAndRunTest('Live with initial values', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },
@@ -304,7 +304,7 @@ prepareAndRunTest('Live with seq values', dir, (t, db, raf) => {
         type: 'EQUAL',
         data: {
           seek: helpers.seekType,
-          value: Buffer.from('post'),
+          value: helpers.toBipf('post'),
           indexType: 'type',
           indexName: 'type_post',
         },
@@ -355,7 +355,7 @@ prepareAndRunTest('Live with cleanup', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },

--- a/test/operators.js
+++ b/test/operators.js
@@ -64,7 +64,7 @@ prepareAndRunTest('operators API supports equal', dir, (t, db, raf) => {
 
   t.equal(queryTree.data.indexType, 'type')
   t.equal(queryTree.data.indexAll, true)
-  t.deepEqual(queryTree.data.value, Buffer.from('post'))
+  t.deepEqual(queryTree.data.value, helpers.toBipf('post'))
   t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
 
   t.equal(typeof queryTree.meta, 'object', 'queryTree contains meta')
@@ -94,7 +94,7 @@ prepareAndRunTest('operators API supports slowEqual', dir, (t, db, raf) => {
 
   t.equal(queryTree.data.indexType, 'value_content_type')
   t.notOk(queryTree.data.indexAll)
-  t.deepEqual(queryTree.data.value, Buffer.from('post'))
+  t.deepEqual(queryTree.data.value, helpers.toBipf('post'))
   t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
 
   t.equal(typeof queryTree.meta, 'object', 'queryTree contains meta')
@@ -127,7 +127,7 @@ prepareAndRunTest('query ignores non-function arguments', dir, (t, db, raf) => {
 
   t.equal(queryTree.data.indexType, 'type')
   t.equal(queryTree.data.indexAll, true)
-  t.deepEqual(queryTree.data.value, Buffer.from('post'))
+  t.deepEqual(queryTree.data.value, helpers.toBipf('post'))
   t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
 
   t.equal(typeof queryTree.meta, 'object', 'queryTree contains meta')
@@ -191,7 +191,7 @@ prepareAndRunTest('slowEqual 3 args', dir, (t, db, raf) => {
 
   t.equal(queryTree.data.indexType, 'value_content_type')
   t.equal(queryTree.data.indexAll, true)
-  t.deepEqual(queryTree.data.value, Buffer.from('post'))
+  t.deepEqual(queryTree.data.value, helpers.toBipf('post'))
   t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
 
   t.end()
@@ -207,7 +207,7 @@ prepareAndRunTest('equal with null value', dir, (t, db, raf) => {
   t.equal(queryTree.type, 'EQUAL')
 
   t.equal(queryTree.data.indexType, 'channel')
-  t.notOk(queryTree.data.value)
+  t.deepEqual(queryTree.data.value, helpers.toBipf(null))
   t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
 
   t.end()
@@ -223,7 +223,7 @@ prepareAndRunTest('equal with undefined value', dir, (t, db, raf) => {
   t.equal(queryTree.type, 'EQUAL')
 
   t.equal(queryTree.data.indexType, 'channel')
-  t.notOk(queryTree.data.value)
+  t.deepEqual(queryTree.data.value, helpers.toBipf(undefined))
   t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
 
   t.end()
@@ -240,7 +240,7 @@ prepareAndRunTest('equal with prefix', dir, (t, db, raf) => {
   t.equal(queryTree.type, 'EQUAL')
 
   t.equal(queryTree.data.indexType, 'type')
-  t.deepEqual(queryTree.data.value, Buffer.from('post'))
+  t.deepEqual(queryTree.data.value, helpers.toBipf('post'))
   t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
   t.equal(queryTree.data.prefix, 32)
 
@@ -258,7 +258,7 @@ prepareAndRunTest('slowEqual with prefix', dir, (t, db, raf) => {
   t.equal(queryTree.type, 'EQUAL')
 
   t.equal(queryTree.data.indexType, 'value_content_type')
-  t.deepEqual(queryTree.data.value, Buffer.from('post'))
+  t.deepEqual(queryTree.data.value, helpers.toBipf('post'))
   t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
   t.equal(queryTree.data.prefix, 32)
 
@@ -275,7 +275,7 @@ prepareAndRunTest('includes()', dir, (t, db, raf) => {
   t.equal(queryTree.type, 'INCLUDES')
 
   t.equal(queryTree.data.indexType, 'animals')
-  t.deepEqual(queryTree.data.value, Buffer.from('cat'))
+  t.deepEqual(queryTree.data.value, helpers.toBipf('cat'))
   t.true(queryTree.data.seek.toString().includes('bipf.seekKey'))
 
   t.end()
@@ -297,21 +297,21 @@ prepareAndRunTest('operators API supports or()', dir, (t, db, raf) => {
 
   t.equal(queryTree.data[0].type, 'EQUAL')
   t.equal(queryTree.data[0].data.indexType, 'value_content_type')
-  t.deepEqual(queryTree.data[0].data.value, Buffer.from('post'))
+  t.deepEqual(queryTree.data[0].data.value, helpers.toBipf('post'))
 
   t.equal(queryTree.data[1].type, 'OR')
   t.true(Array.isArray(queryTree.data[1].data), '.data[1].data is an array')
 
   t.equal(queryTree.data[1].data[0].type, 'EQUAL')
   t.deepEqual(queryTree.data[1].data[0].data.indexType, 'value_author')
-  t.deepEqual(queryTree.data[1].data[0].data.value, Buffer.from(alice.id))
+  t.deepEqual(queryTree.data[1].data[0].data.value, helpers.toBipf(alice.id))
   t.true(
     queryTree.data[1].data[0].data.seek.toString().includes('bipf.seekKey')
   )
 
   t.equal(queryTree.data[1].data[1].type, 'EQUAL')
   t.equal(queryTree.data[1].data[1].data.indexType, 'value_author')
-  t.deepEqual(queryTree.data[1].data[1].data.value, Buffer.from(bob.id))
+  t.deepEqual(queryTree.data[1].data[1].data.value, helpers.toBipf(bob.id))
   t.true(
     queryTree.data[1].data[1].data.seek.toString().includes('bipf.seekKey')
   )
@@ -475,7 +475,7 @@ prepareAndRunTest('operator gt', dir, (t, db, raf) => {
 
   t.equal(queryTree.data[0].type, 'EQUAL')
   t.equal(queryTree.data[0].data.indexType, 'author')
-  t.deepEqual(queryTree.data[0].data.value, Buffer.from(alice.id))
+  t.deepEqual(queryTree.data[0].data.value, helpers.toBipf(alice.id))
   t.true(queryTree.data[0].data.seek.toString().includes('bipf.seekKey'))
 
   t.equal(queryTree.data[1].type, 'GT')

--- a/test/operators.js
+++ b/test/operators.js
@@ -41,6 +41,8 @@ const {
   toPullStream,
   toAsyncIter,
   slowPredicate,
+  slowAbsent,
+  absent,
 } = require('../operators')
 
 const dir = '/tmp/jitdb-query-api'
@@ -1434,6 +1436,64 @@ prepareAndRunTest('support slowPredicate', dir, (t, db, raf) => {
             t.equal(msgs.length, 2, 'got two messages')
             t.equal(msgs[0].value.content.text, '2nd')
             t.equal(msgs[1].value.content.text, '3rd')
+            t.end()
+          })
+        )
+      })
+    })
+  })
+})
+
+prepareAndRunTest('support slowAbsent', dir, (t, db, raf) => {
+  const msg1 = { type: 'post', text: '1st', animal: 'bird' }
+  const msg2 = { type: 'contact', text: '2nd' }
+  const msg3 = { type: 'post', text: '3rd', animal: 'dog' }
+
+  let state = validate.initial()
+  state = validate.appendNew(state, null, alice, msg1, Date.now())
+  state = validate.appendNew(state, null, alice, msg2, Date.now() + 1)
+  state = validate.appendNew(state, null, alice, msg3, Date.now() + 2)
+
+  addMsg(state.queue[0].value, raf, (e1, m1) => {
+    addMsg(state.queue[1].value, raf, (e2, m2) => {
+      addMsg(state.queue[2].value, raf, (e3, m3) => {
+        query(
+          fromDB(db),
+          where(slowAbsent('value.content.animal')),
+          toCallback((err, msgs) => {
+            t.error(err, 'got no error')
+            t.equal(msgs.length, 1, 'got one message')
+            t.equal(msgs[0].value.content.text, '2nd')
+            t.end()
+          })
+        )
+      })
+    })
+  })
+})
+
+prepareAndRunTest('support absent', dir, (t, db, raf) => {
+  const msg1 = { type: 'post', text: '1st', channel: 'food' }
+  const msg2 = { type: 'contact', text: '2nd' }
+  const msg3 = { type: 'post', text: '3rd', channel: 'cats' }
+
+  let state = validate.initial()
+  state = validate.appendNew(state, null, alice, msg1, Date.now())
+  state = validate.appendNew(state, null, alice, msg2, Date.now() + 1)
+  state = validate.appendNew(state, null, alice, msg3, Date.now() + 2)
+
+  addMsg(state.queue[0].value, raf, (e1, m1) => {
+    addMsg(state.queue[1].value, raf, (e2, m2) => {
+      addMsg(state.queue[2].value, raf, (e3, m3) => {
+        query(
+          fromDB(db),
+          where(
+            absent(helpers.seekChannel, { indexType: 'value_content_channel' })
+          ),
+          toCallback((err, msgs) => {
+            t.error(err, 'got no error')
+            t.equal(msgs.length, 1, 'got one message')
+            t.equal(msgs[0].value.content.text, '2nd')
             t.end()
           })
         )

--- a/test/prefix.js
+++ b/test/prefix.js
@@ -31,7 +31,7 @@ prepareAndRunTest('Prefix equal', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'value_content_type_post',
       prefix: 32,
@@ -66,7 +66,7 @@ prepareAndRunTest('Normal index renamed to prefix', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'value_content_type_post',
     },
@@ -76,7 +76,7 @@ prepareAndRunTest('Normal index renamed to prefix', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'value_content_type',
       prefix: 32,
@@ -116,7 +116,7 @@ prepareAndRunTest('Prefix index skips deleted records', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'value_content_type_post',
       prefix: 32,
@@ -128,7 +128,7 @@ prepareAndRunTest('Prefix index skips deleted records', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'value_content_type_post',
       prefix: 32,
@@ -171,7 +171,7 @@ prepareAndRunTest('Prefix larger than actual value', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekChannel,
-      value: Buffer.from('foo'),
+      value: helpers.toBipf('foo'),
       indexType: 'channel',
       indexName: 'value_content_channel_foo',
       prefix: 32,
@@ -267,7 +267,7 @@ prepareAndRunTest('Prefix equal', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekVoteLink,
-      value: Buffer.from(
+      value: helpers.toBipf(
         '%wOtfXXopI3mTHL6F7Y3XXNtpxws9mQdaEocNJuKtAZo=.sha256'
       ),
       indexType: 'vote',
@@ -325,7 +325,7 @@ prepareAndRunTest('Prefix equal unknown value', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekAuthor,
-      value: Buffer.from('abc'),
+      value: helpers.toBipf('abc'),
       indexType: 'author',
       indexName: 'value_author_abc',
       prefix: 32,
@@ -358,7 +358,7 @@ prepareAndRunTest('Prefix map equal', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'value_content_type_post',
       useMap: true,
@@ -397,7 +397,7 @@ prepareAndRunTest('Prefix offset', dir, (t, db, raf) => {
           type: 'EQUAL',
           data: {
             seek: helpers.seekKey,
-            value: Buffer.from(msg.key),
+            value: helpers.toBipf(msg.key),
             indexType: 'key',
             indexName: 'value_key_' + msg.key,
             useMap: true,
@@ -427,7 +427,7 @@ prepareAndRunTest('Prefix offset 1 on empty', dir, (t, db, raf) => {
       type: 'EQUAL',
       data: {
         seek: helpers.seekRoot,
-        value: Buffer.from('test'),
+        value: helpers.toBipf('test'),
         indexType: 'root',
         indexName: 'value_content_root',
         useMap: true,
@@ -458,7 +458,7 @@ prepareAndRunTest('Prefix delete', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'value_content_type_post',
       useMap: true,
@@ -469,7 +469,7 @@ prepareAndRunTest('Prefix delete', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekAuthor,
-      value: Buffer.from(keys.id),
+      value: helpers.toBipf(keys.id),
       indexType: 'author',
       indexName: 'value_author',
       prefix: 32,

--- a/test/query.js
+++ b/test/query.js
@@ -32,7 +32,7 @@ prepareAndRunTest('Multiple types', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },
@@ -42,7 +42,7 @@ prepareAndRunTest('Multiple types', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('contact'),
+      value: helpers.toBipf('contact'),
       indexType: 'type',
       indexName: 'type_contact',
     },
@@ -82,7 +82,7 @@ prepareAndRunTest('Top 1 multiple types', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },
@@ -111,7 +111,7 @@ prepareAndRunTest('Limit -1', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },
@@ -136,7 +136,7 @@ prepareAndRunTest('Limit 0', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },
@@ -165,7 +165,7 @@ prepareAndRunTest('Includes', dir, (t, db, raf) => {
     type: 'INCLUDES',
     data: {
       seek: helpers.seekAnimals,
-      value: Buffer.from('bird'),
+      value: helpers.toBipf('bird'),
       indexType: 'animals',
       indexName: 'animals_bird',
     },
@@ -212,7 +212,7 @@ prepareAndRunTest('Includes and pluck', dir, (t, db, raf) => {
     type: 'INCLUDES',
     data: {
       seek: helpers.seekAnimals,
-      value: Buffer.from('bird'),
+      value: helpers.toBipf('bird'),
       indexType: 'animals_word',
       indexName: 'animals_word_bird',
       pluck: helpers.pluckWord,
@@ -248,7 +248,7 @@ prepareAndRunTest('Paginate many pages', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },
@@ -287,7 +287,7 @@ prepareAndRunTest('Paginate empty', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('blog'),
+      value: helpers.toBipf('blog'),
       indexType: 'type',
       indexName: 'type_blog',
     },
@@ -318,7 +318,7 @@ prepareAndRunTest('Seq', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },
@@ -347,7 +347,7 @@ prepareAndRunTest('Buffer', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },
@@ -376,7 +376,7 @@ prepareAndRunTest('Undefined', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekRoot,
-      value: undefined,
+      value: helpers.toBipf(undefined),
       indexType: 'root',
       indexName: 'root_',
     },
@@ -410,7 +410,7 @@ prepareAndRunTest('Null', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekRoot,
-      value: null,
+      value: helpers.toBipf(null),
       indexType: 'root',
       indexName: 'root_',
     },
@@ -455,7 +455,7 @@ prepareAndRunTest('GT,GTE,LT,LTE', dir, (t, db, raf) => {
         type: 'EQUAL',
         data: {
           seek: helpers.seekAuthor,
-          value: Buffer.from(keys.id),
+          value: helpers.toBipf(keys.id),
           indexType: 'author',
           indexAll: true,
           indexName: safeFilename('author_' + keys.id),
@@ -571,7 +571,7 @@ prepareAndRunTest('Data offsets', dir, (t, db, raf) => {
         type: 'EQUAL',
         data: {
           seek: helpers.seekType,
-          value: Buffer.from('post'),
+          value: helpers.toBipf('post'),
           indexType: 'type',
           indexName: 'type_post',
         },
@@ -642,7 +642,7 @@ prepareAndRunTest('Data seqs', dir, (t, db, raf) => {
         type: 'EQUAL',
         data: {
           seek: helpers.seekType,
-          value: Buffer.from('post'),
+          value: helpers.toBipf('post'),
           indexType: 'type',
           indexName: 'type_post',
         },
@@ -681,7 +681,7 @@ prepareAndRunTest('Multiple ands', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },
@@ -691,7 +691,7 @@ prepareAndRunTest('Multiple ands', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekAuthor,
-      value: Buffer.from(keys.id),
+      value: helpers.toBipf(keys.id),
       indexType: 'author',
       indexName: 'author_' + keys.id,
     },
@@ -737,7 +737,7 @@ prepareAndRunTest('Multiple ors', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },
@@ -747,7 +747,7 @@ prepareAndRunTest('Multiple ors', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekAuthor,
-      value: Buffer.from('random'),
+      value: helpers.toBipf('random'),
       indexType: 'author',
       indexName: 'author_random',
     },
@@ -757,7 +757,7 @@ prepareAndRunTest('Multiple ors', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekAuthor,
-      value: Buffer.from('random2'),
+      value: helpers.toBipf('random2'),
       indexType: 'author',
       indexName: 'author_random2',
     },
@@ -767,7 +767,7 @@ prepareAndRunTest('Multiple ors', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekAuthor,
-      value: Buffer.from(keys.id),
+      value: helpers.toBipf(keys.id),
       indexType: 'author',
       indexName: 'author_' + keys.id,
     },
@@ -813,7 +813,7 @@ prepareAndRunTest('Timestamp discontinuity', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekAuthor,
-      value: Buffer.from(keys.id),
+      value: helpers.toBipf(keys.id),
       indexType: 'author',
       indexName: 'author_me',
     },
@@ -851,7 +851,7 @@ prepareAndRunTest('reindex corrupt indexes', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },

--- a/test/reindex.js
+++ b/test/reindex.js
@@ -72,7 +72,7 @@ prepareAndRunTest('reindex seq offset', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },
@@ -109,7 +109,7 @@ prepareAndRunTest('reindex bitset', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },
@@ -138,7 +138,7 @@ prepareAndRunTest('reindex prefix', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post_prefix',
       prefix: 32,
@@ -169,7 +169,7 @@ prepareAndRunTest('reindex prefix map', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post_prefix',
       prefix: 32,

--- a/test/seq-index-not-uptodate.js
+++ b/test/seq-index-not-uptodate.js
@@ -31,7 +31,7 @@ prepareAndRunTest('Ensure seq index is updated always', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },

--- a/test/slow-save.js
+++ b/test/slow-save.js
@@ -42,7 +42,7 @@ prepareAndRunTest('wip-index-save', dir, (t, db, raf) => {
     type: 'EQUAL',
     data: {
       seek: helpers.seekType,
-      value: Buffer.from('post'),
+      value: helpers.toBipf('post'),
       indexType: 'type',
       indexName: 'type_post',
     },


### PR DESCRIPTION
This is a breaking change. Luckily it is only breaking for clients calling with an operation directly instead of using `equal` and friends. This PR aims to solve #178 by changing values to always be bipf encoded instead of buffers. This change also makes things a bit clearer on how equal works I think. Either you give a specific value in which case the value inside the buffer must match exactly (this includes null, undefined, booleans and also numbers that was not working properly before) OR the field is not defined in which cases undefined also matches.

This PR grew out of https://github.com/ssb-ngi-pointer/jitdb/pull/181 which is an attempt to solve the same problem in a backwards compatible way. The changes needed to ssb-db2 to work with this branch is surprisingly few because most thing rely on equal, that automatically handles this. 