### PR TITLE
add 'absent' example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ const bipf = require('bipf')
 const assert = require("assert");
 const B_VALUE = Buffer.from('value')
 const B_CHANNEL = Buffer.from('channel')
+const B_CONTENT = Buffer.from('content')
 
 query(
   fromDB(db),

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ query(
   ),
   toCallback((err, msgs) => {
     assert.equal(err, null, 'got no error')
+    // do something with msgs...
   })
 )
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,41 @@ function seekAuthor(buffer) {
 }
 ```
 
+**get messages without 'value' as channel**
+
+An example using the `absent` operator
+
+```js
+const { query } = require('jitdb/operators')
+const bipf = require('bipf')
+const assert = require("assert");
+const B_VALUE = Buffer.from('value')
+const B_CHANNEL = Buffer.from('channel')
+
+query(
+  fromDB(db),
+  where(
+    and(
+        absent(seekChannel, { indexType: 'value_content_channel' })
+        type('post')
+    )
+  ),
+  toCallback((err, msgs) => {
+    assert.equal(err, null, 'got no error')
+  })
+)
+
+function seekChannel (buffer) {
+  var p = 0 // note you pass in p!
+  p = bipf.seekKey(buffer, p, B_VALUE)
+
+  if (~p) {
+    p = bipf.seekKey(buffer, p, B_CONTENT)
+    if (~p) return bipf.seekKey(buffer, p, B_CHANNEL)
+  }
+}
+```
+
 #### Pagination
 
 If you use `toCallback`, it gives you all results in one go. If you

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ function seekAuthor(buffer) {
 An example using the `absent` operator
 
 ```js
-const { query } = require('jitdb/operators')
+const { query, fromDB, where, and, toCallback } = require('jitdb/operators')
 const bipf = require('bipf')
 const assert = require("assert");
 const B_VALUE = Buffer.from('value')

--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ query(
   fromDB(db),
   where(
     and(
-        absent(seekChannel, { indexType: 'value_content_channel' })
-        type('post')
+      absent(seekChannel, { indexType: 'value_content_channel' })
+      type('post')
     )
   ),
   toCallback((err, msgs) => {


### PR DESCRIPTION
This adds an example to the readme

The example was taken directly from the test file, and shows the `seek` function as well.

Any help with the way things are worded would be appreciated

related to #190 

