### PR TITLE
Sort by

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ const {
   startFrom,
   descending,
   asOffsets,
+  sortBy,
   debug,
   toCallback,
   toPullStream,
@@ -487,12 +488,17 @@ First some terminology: offset refers to the byte position in the log
 of a message. Seq refers to the 0-based position of a message in the
 log.
 
-### paginate(operation, seq, limit, descending, onlyOffset, cb)
+### paginate(operation, seq, limit, descending, onlyOffset, sortBy, cb)
 
 Query the database returning paginated results. If one or more indexes
 doesn't exist or are outdated, the indexes will be updated before the
 query is run. `onlyOffset` can be used to return offset instead of the
-actual messages. The result is an object with the fields:
+actual messages. `sortBy` defaults to creation time of messages. By
+setting this to `arrival`, the results are sorted by when they were
+added to the database. This can be important for messages from other
+peers that might arrive out of order compared when they were created.
+
+The result is an object with the fields:
 
 - `data`: the actual messages
 - `total`: the total number of messages
@@ -551,7 +557,7 @@ some after processing that you wouldn't create and index for, but the
 overhead of decoding the buffers is small enough that I don't think it
 makes sense.
 
-### all(operation, seq, descending, onlyOffset, cb)
+### all(operation, seq, descending, onlyOffset, sortBy, cb)
 
 Similar to `paginate` except there is no `limit` argument and the result
 will be the messages directly.

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ const {
   startFrom,
   descending,
   asOffsets,
-  sortBy,
+  sortByArrival,
   debug,
   toCallback,
   toPullStream,

--- a/index.js
+++ b/index.js
@@ -1197,13 +1197,14 @@ module.exports = function (log, indexesPath) {
     const fpq = new FastPriorityQueue(
       descending ? compareDescending : compareAscending
     )
-    bitset.forEach((seq) => {
-      fpq.add({
-        seq,
-        timestamp: indexes['timestamp'].tarr[seq],
+    fpq.heapify(
+      bitset.array().map((seq) => {
+        return {
+          seq,
+          timestamp: indexes['timestamp'].tarr[seq],
+        }
       })
-    })
-    fpq.trim()
+    )
     sortedCache[order].set(bitset, fpq)
     return fpq
   }
@@ -1261,8 +1262,8 @@ module.exports = function (log, indexesPath) {
       )
 
       sorted.heapify(
-        bitset.array().map((x) => {
-          return { seq: x }
+        bitset.array().map((seq) => {
+          return { seq }
         })
       )
     } else sorted = sortedByTimestamp(bitset, descending)

--- a/index.js
+++ b/index.js
@@ -1181,11 +1181,11 @@ module.exports = function (log, indexesPath) {
     })
   }
 
-  function compareAscending(a, b) {
+  function compareTSAscending(a, b) {
     return b.timestamp > a.timestamp
   }
 
-  function compareDescending(a, b) {
+  function compareTSDescending(a, b) {
     return a.timestamp > b.timestamp
   }
 
@@ -1207,8 +1207,8 @@ module.exports = function (log, indexesPath) {
           ? compareSeqDescending
           : compareSeqAscending
         : descending
-        ? compareDescending
-        : compareAscending
+        ? compareTSDescending
+        : compareTSAscending
 
     if (sortedCache[order].has(bitset)) return sortedCache[order].get(bitset)
     const fpq = new FastPriorityQueue(comparer)

--- a/index.js
+++ b/index.js
@@ -1182,6 +1182,14 @@ module.exports = function (log, indexesPath) {
     return a.timestamp > b.timestamp
   }
 
+  function compareSeqAscending(a, b) {
+    return b.seq > a.seq
+  }
+
+  function compareSeqDescending(a, b) {
+    return a.seq > b.seq
+  }
+
   function sortedByTimestamp(bitset, descending) {
     updateCacheWithLog()
     const order = descending ? 'descending' : 'ascending'
@@ -1248,8 +1256,10 @@ module.exports = function (log, indexesPath) {
 
     let sorted
     if (sortBy === 'arrival') {
-      sorted = new FastPriorityQueue()
-      // already sorted by arrival time in log
+      sorted = new FastPriorityQueue(
+        descending ? compareSeqDescending : compareSeqAscending
+      )
+
       sorted.heapify(
         bitset.array().map((x) => {
           return { seq: x }

--- a/operators.js
+++ b/operators.js
@@ -387,6 +387,10 @@ function descending() {
   return (ops) => updateMeta(ops, 'descending', true)
 }
 
+function sortBy(sortOption) {
+  return (ops) => updateMeta(ops, 'sortBy', sortOption)
+}
+
 function startFrom(seq) {
   return (ops) => updateMeta(ops, 'seq', seq)
 }
@@ -480,11 +484,19 @@ function toCallback(cb) {
       if (end) return cb(end)
 
       const seq = meta.seq || 0
-      const { pageSize, descending, asOffsets } = meta
+      const { pageSize, descending, asOffsets, sortBy } = meta
       if (meta.count) meta.jitdb.count(ops, seq, descending, cb)
       else if (pageSize)
-        meta.jitdb.paginate(ops, seq, pageSize, descending, asOffsets, cb)
-      else meta.jitdb.all(ops, seq, descending, asOffsets, cb)
+        meta.jitdb.paginate(
+          ops,
+          seq,
+          pageSize,
+          descending,
+          asOffsets,
+          sortBy,
+          cb
+        )
+      else meta.jitdb.all(ops, seq, descending, asOffsets, sortBy, cb)
     })
   }
 }
@@ -517,6 +529,7 @@ function toPullStream() {
             limit,
             meta.descending,
             meta.asOffsets,
+            meta.sortBy,
             (err, answer) => {
               if (err) return cb(err)
               else if (answer.total === 0) cb(true)
@@ -588,6 +601,7 @@ module.exports = {
   offsets,
 
   descending,
+  sortBy,
   count,
   startFrom,
   paginate,

--- a/operators.js
+++ b/operators.js
@@ -387,8 +387,8 @@ function descending() {
   return (ops) => updateMeta(ops, 'descending', true)
 }
 
-function sortBy(sortOption) {
-  return (ops) => updateMeta(ops, 'sortBy', sortOption)
+function sortByArrival() {
+  return (ops) => updateMeta(ops, 'sortBy', 'arrival')
 }
 
 function startFrom(seq) {
@@ -601,7 +601,7 @@ module.exports = {
   offsets,
 
   descending,
-  sortBy,
+  sortByArrival,
   count,
   startFrom,
   paginate,

--- a/test/operators.js
+++ b/test/operators.js
@@ -35,7 +35,7 @@ const {
   live,
   count,
   descending,
-  sortBy,
+  sortByArrival,
   asOffsets,
   toCallback,
   toPromise,
@@ -443,7 +443,7 @@ prepareAndRunTest(
     const queryTreeSortBy = query(
       fromDB(db),
       where(slowEqual('value.content.type', 'post')),
-      sortBy('arrival')
+      sortByArrival()
     )
 
     const queryTreeAll = query(
@@ -452,7 +452,7 @@ prepareAndRunTest(
       startFrom(5),
       paginate(10),
       descending(),
-      sortBy('arrival')
+      sortByArrival()
     )
 
     t.equal(queryTreePaginate.meta.pageSize, 10)
@@ -957,7 +957,7 @@ prepareAndRunTest('operators toCallback with sortBy', dir, (t, db, raf) => {
             slowEqual('value.author', bob.id)
           )
         ),
-        sortBy('arrival'),
+        sortByArrival(),
         toCallback((err, msgs) => {
           t.error(err, 'toCallback got no error')
           t.equal(msgs.length, 2, 'toCallback got two messages')


### PR DESCRIPTION
# Background

I was working on adding a [list method](https://gitlab.com/ahau/lib/ssb-crut/-/merge_requests/25) to ssb-crut together with @mixmix and we got to talk about sorting of the results. We would like to support to modes of sorting: creation time and receive (or arrival) time. Right now results from jitdb are sorted by creation time, unless creation time is after arrival time, in which case we use arrival time. This is mostly to handle computers with wrong local time writing messages in the *future*. This can then be returned as ascending or descending. The purpose for this is sorting data where data from one or more peers are delayed. Lets say you have a list of latest comments or something like that. And you sort by creation time. Later you receive some messages from a peer that was offline the first time around. The results might then be displayed in the middle of the list instead of top. While both are equally true, depending on how this is displayed in the UI it might be good to support both methods of ordering.

What this PR does is add a `sortBy` operator that defaults to existing creation time behaviour. If set to `arrival` the results will be sorted by when they are written to disc instead of creation time.