### PR TITLE
Implement group by

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ First some terminology: offset refers to the byte position in the log
 of a message. Seq refers to the 0-based position of a message in the
 log.
 
-### paginate(operation, seq, limit, descending, onlyOffset, sortBy, cb)
+### paginate(operation, seq, limit, descending, onlyOffset, sortBy, groupBy, cb)
 
 Query the database returning paginated results. If one or more indexes
 doesn't exist or are outdated, the indexes will be updated before the
@@ -497,7 +497,10 @@ ordering messages. Can take values `declared` or `arrival`. `declared`
 refers to the timestamp for when a message was created, while
 `arrival` refers to when a message was added to the database. This can
 be important for messages from other peers that might arrive out of
-order compared when they were created.
+order compared when they were created. `groupBy` if used, must be a
+function that takes a buffer as input and returns an index in the
+buffer of the value used for grouping. The idea is to only get 1
+result per grouped value.
 
 The result is an object with the fields:
 

--- a/operators.js
+++ b/operators.js
@@ -391,6 +391,10 @@ function sortByArrival() {
   return (ops) => updateMeta(ops, 'sortBy', 'arrival')
 }
 
+function groupBy(seek) {
+  return (ops) => updateMeta(ops, 'groupBy', seek)
+}
+
 function startFrom(seq) {
   return (ops) => updateMeta(ops, 'seq', seq)
 }
@@ -484,7 +488,7 @@ function toCallback(cb) {
       if (end) return cb(end)
 
       const seq = meta.seq || 0
-      const { pageSize, descending, asOffsets, sortBy } = meta
+      const { pageSize, descending, asOffsets, sortBy, groupBy } = meta
       if (meta.count) meta.jitdb.count(ops, seq, descending, cb)
       else if (pageSize)
         meta.jitdb.paginate(
@@ -494,9 +498,10 @@ function toCallback(cb) {
           descending,
           asOffsets,
           sortBy,
+          groupBy,
           cb
         )
-      else meta.jitdb.all(ops, seq, descending, asOffsets, sortBy, cb)
+      else meta.jitdb.all(ops, seq, descending, asOffsets, sortBy, groupBy, cb)
     })
   }
 }
@@ -530,6 +535,7 @@ function toPullStream() {
             meta.descending,
             meta.asOffsets,
             meta.sortBy,
+            meta.groupBy,
             (err, answer) => {
               if (err) return cb(err)
               else if (answer.total === 0) cb(true)
@@ -602,6 +608,7 @@ module.exports = {
 
   descending,
   sortByArrival,
+  groupBy,
   count,
   startFrom,
   paginate,

--- a/test/add.js
+++ b/test/add.js
@@ -45,6 +45,7 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
         false,
         false,
         'declared',
+        null,
         (err, { results }) => {
           t.equal(results.length, 2)
 
@@ -56,6 +57,7 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
             true,
             false,
             'declared',
+            null,
             (err, { results }) => {
               t.equal(results.length, 2)
               t.equal(results[0].value.author, keys2.id)
@@ -67,6 +69,7 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
                 false,
                 false,
                 'declared',
+                null,
                 (err, { results }) => {
                   t.equal(results.length, 2)
                   t.equal(results[0].value.author, keys.id)
@@ -87,6 +90,7 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
                     false,
                     false,
                     'declared',
+                    null,
                     (err, { results }) => {
                       t.equal(results.length, 1)
                       t.equal(results[0].id, msg1.id)
@@ -99,6 +103,7 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
                         false,
                         false,
                         'declared',
+                        null,
                         (err, { results }) => {
                           t.equal(results.length, 1)
                           t.equal(results[0].id, msg1.id)
@@ -113,6 +118,7 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
                             false,
                             false,
                             'declared',
+                            null,
                             (err, { results }) => {
                               t.equal(results.length, 1)
                               t.equal(results[0].id, msg1.id)
@@ -143,6 +149,7 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
                                 false,
                                 false,
                                 'declared',
+                                null,
                                 (err, { results }) => {
                                   t.equal(results.length, 2)
                                   t.end()
@@ -185,13 +192,13 @@ prepareAndRunTest('Update index', dir, (t, db, raf) => {
   t.equal(typeof db.status.value['type_post'], 'undefined')
 
   addMsg(state.queue[0].value, raf, (err, msg1) => {
-    db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
+    db.all(typeQuery, 0, false, false, 'declared', null, (err, results) => {
       t.equal(results.length, 1)
       t.equal(db.status.value['seq'], 0)
       t.equal(db.status.value['type_post'], 0)
 
       addMsg(state.queue[1].value, raf, (err, msg1) => {
-        db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
+        db.all(typeQuery, 0, false, false, 'declared', null, (err, results) => {
           t.equal(results.length, 2)
           t.equal(db.status.value['seq'], 352)
           t.equal(db.status.value['type_post'], 352)
@@ -227,7 +234,7 @@ prepareAndRunTest('obsolete status parts disappear', dir, (t, db, raf) => {
       addMsg(q.value, raf, cb)
     }),
     push.collect(() => {
-      db.paginate(typeQuery, 0, 1, false, false, 'declared', () => {
+      db.paginate(typeQuery, 0, 1, false, false, 'declared', null, () => {
         t.pass(JSON.stringify(db.status.value))
         t.ok(db.status.value['seq'])
         t.ok(db.status.value['type_post'])
@@ -254,13 +261,22 @@ prepareAndRunTest('obsolete status parts disappear', dir, (t, db, raf) => {
             addMsg(q.value, raf, cb)
           }),
           push.collect(() => {
-            db.paginate(aboutQuery, 0, 1, false, false, 'declared', () => {
-              t.pass(JSON.stringify(db.status.value))
-              t.ok(db.status.value['seq'])
-              t.notOk(db.status.value['type_post'])
-              t.ok(db.status.value['type_about'])
-              t.end()
-            })
+            db.paginate(
+              aboutQuery,
+              0,
+              1,
+              false,
+              false,
+              'declared',
+              null,
+              () => {
+                t.pass(JSON.stringify(db.status.value))
+                t.ok(db.status.value['seq'])
+                t.notOk(db.status.value['type_post'])
+                t.ok(db.status.value['type_about'])
+                t.end()
+              }
+            )
           })
         )
       })
@@ -300,6 +316,7 @@ prepareAndRunTest('grow', dir, (t, db, raf) => {
         false,
         false,
         'declared',
+        null,
         (err, { results }) => {
           t.equal(results.length, 1)
           t.equal(results[0].value.content.text, 'Testing 31999')
@@ -350,13 +367,21 @@ prepareAndRunTest('indexAll', dir, (t, db, raf) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
         addMsg(state.queue[3].value, raf, (err, msg) => {
-          db.all(authorQuery, 0, false, false, 'declared', (err, results) => {
-            t.error(err)
-            t.equal(results.length, 1)
-            t.equal(results[0].value.content.text, 'Testing 1')
-            t.equal(Object.keys(db.indexes).length, 3 + 2 + 1 + 1)
-            t.end()
-          })
+          db.all(
+            authorQuery,
+            0,
+            false,
+            false,
+            'declared',
+            null,
+            (err, results) => {
+              t.error(err)
+              t.equal(results.length, 1)
+              t.equal(results[0].value.content.text, 'Testing 1')
+              t.equal(Object.keys(db.indexes).length, 3 + 2 + 1 + 1)
+              t.end()
+            }
+          )
         })
       })
     })
@@ -389,40 +414,55 @@ prepareAndRunTest('indexAll multiple reindexes', dir, (t, db, raf) => {
 
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
-      db.all(typeQuery('post'), 0, false, false, 'declared', (err, results) => {
-        t.equal(results.length, 1)
-        t.equal(results[0].value.content.text, 'Testing 1')
+      db.all(
+        typeQuery('post'),
+        0,
+        false,
+        false,
+        'declared',
+        null,
+        (err, results) => {
+          t.equal(results.length, 1)
+          t.equal(results[0].value.content.text, 'Testing 1')
 
-        addMsg(state.queue[2].value, raf, (err, msg) => {
-          addMsg(state.queue[3].value, raf, (err, msg) => {
-            db.all(
-              typeQuery('about'),
-              0,
-              false,
-              false,
-              'declared',
-              (err, results) => {
-                t.equal(results.length, 1)
+          addMsg(state.queue[2].value, raf, (err, msg) => {
+            addMsg(state.queue[3].value, raf, (err, msg) => {
+              db.all(
+                typeQuery('about'),
+                0,
+                false,
+                false,
+                'declared',
+                null,
+                (err, results) => {
+                  t.equal(results.length, 1)
 
-                db.all(
-                  typeQuery('post'),
-                  0,
-                  false,
-                  false,
-                  'declared',
-                  (err, results) => {
-                    t.equal(results.length, 2)
-                    t.deepEqual(db.indexes['type_post'].bitset.array(), [0, 2])
-                    t.deepEqual(db.indexes['type_contact'].bitset.array(), [1])
-                    t.deepEqual(db.indexes['type_about'].bitset.array(), [3])
-                    t.end()
-                  }
-                )
-              }
-            )
+                  db.all(
+                    typeQuery('post'),
+                    0,
+                    false,
+                    false,
+                    'declared',
+                    null,
+                    (err, results) => {
+                      t.equal(results.length, 2)
+                      t.deepEqual(db.indexes['type_post'].bitset.array(), [
+                        0,
+                        2,
+                      ])
+                      t.deepEqual(db.indexes['type_contact'].bitset.array(), [
+                        1,
+                      ])
+                      t.deepEqual(db.indexes['type_about'].bitset.array(), [3])
+                      t.end()
+                    }
+                  )
+                }
+              )
+            })
           })
-        })
-      })
+        }
+      )
     })
   })
 })

--- a/test/bump-version.js
+++ b/test/bump-version.js
@@ -40,7 +40,7 @@ prepareAndRunTest('Bitvector index version bumped', dir, (t, db, raf) => {
   }
 
   addMsg(state.queue[0].value, raf, (err, msg) => {
-    db.all(postQuery, 0, false, false, 'declared', (err, results) => {
+    db.all(postQuery, 0, false, false, 'declared', null, (err, results) => {
       t.error(err)
       t.equal(results.length, 1)
       t.equal(results[0].value.content.text, 'Testing 1')
@@ -56,7 +56,7 @@ prepareAndRunTest('Bitvector index version bumped', dir, (t, db, raf) => {
         },
       }
 
-      db.all(postQuery2, 0, false, false, 'declared', (err, results) => {
+      db.all(postQuery2, 0, false, false, 'declared', null, (err, results) => {
         t.error(err)
         t.equal(results.length, 1)
         t.equal(results[0].value.content.text, 'Testing 1')
@@ -84,7 +84,7 @@ prepareAndRunTest('Prefix map index version bumped', dir, (t, db, raf) => {
           },
         }
 
-        db.all(keyQuery, 0, false, false, 'declared', (err, results) => {
+        db.all(keyQuery, 0, false, false, 'declared', null, (err, results) => {
           t.equal(results.length, 1)
           t.equal(results[0].value.content.text, 'Testing post 2!')
 
@@ -102,11 +102,19 @@ prepareAndRunTest('Prefix map index version bumped', dir, (t, db, raf) => {
             },
           }
 
-          db.all(keyQuery2, 0, false, false, 'declared', (err, results) => {
-            t.equal(results.length, 1)
-            t.equal(results[0].value.content.text, 'Testing post 2!')
-            t.end()
-          })
+          db.all(
+            keyQuery2,
+            0,
+            false,
+            false,
+            'declared',
+            null,
+            (err, results) => {
+              t.equal(results.length, 1)
+              t.equal(results[0].value.content.text, 'Testing post 2!')
+              t.end()
+            }
+          )
         })
       })
     })

--- a/test/del.js
+++ b/test/del.js
@@ -46,13 +46,22 @@ prepareAndRunTest('Delete', dir, (t, db, raf) => {
             false,
             false,
             'declared',
+            null,
             (err, { results }) => {
               t.deepEqual(results, [msg1, msg3])
 
-              db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
-                t.deepEqual(results, [msg1, msg3])
-                t.end()
-              })
+              db.all(
+                typeQuery,
+                0,
+                false,
+                false,
+                'declared',
+                null,
+                (err, results) => {
+                  t.deepEqual(results, [msg1, msg3])
+                  t.end()
+                }
+              )
             }
           )
         })

--- a/test/live.js
+++ b/test/live.js
@@ -252,7 +252,7 @@ prepareAndRunTest('Live with initial values', dir, (t, db, raf) => {
 
   addMsg(state.queue[0].value, raf, (err, msg1) => {
     // create index
-    db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
+    db.all(typeQuery, 0, false, false, 'declared', null, (err, results) => {
       t.equal(results.length, 1)
 
       pull(
@@ -261,10 +261,18 @@ prepareAndRunTest('Live with initial values', dir, (t, db, raf) => {
           t.equal(result.key, state.queue[1].key)
 
           // rerun on updated index
-          db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
-            t.equal(results.length, 2)
-            t.end()
-          })
+          db.all(
+            typeQuery,
+            0,
+            false,
+            false,
+            'declared',
+            null,
+            (err, results) => {
+              t.equal(results.length, 2)
+              t.end()
+            }
+          )
         })
       )
 
@@ -326,7 +334,7 @@ prepareAndRunTest('Live with seq values', dir, (t, db, raf) => {
   }
 
   addMsg(state.queue[0].value, raf, (err, msg1) => {
-    db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
+    db.all(typeQuery, 0, false, false, 'declared', null, (err, results) => {
       t.equal(results.length, 1)
 
       let liveI = 1

--- a/test/prefix.js
+++ b/test/prefix.js
@@ -41,7 +41,7 @@ prepareAndRunTest('Prefix equal', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
+        db.all(typeQuery, 0, false, false, 'declared', null, (err, results) => {
           t.equal(results.length, 2)
           t.equal(results[0].value.content.type, 'post')
           t.equal(results[1].value.content.type, 'post')
@@ -86,17 +86,33 @@ prepareAndRunTest('Normal index renamed to prefix', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(normalQuery, 0, false, false, 'declared', (err, results) => {
-          t.equal(results.length, 2)
-          t.equal(results[0].value.content.type, 'post')
-          t.equal(results[1].value.content.type, 'post')
-          db.all(prefixQuery, 0, false, false, 'declared', (err, results2) => {
-            t.equal(results2.length, 2)
-            t.equal(results2[0].value.content.type, 'post')
-            t.equal(results2[1].value.content.type, 'post')
-            t.end()
-          })
-        })
+        db.all(
+          normalQuery,
+          0,
+          false,
+          false,
+          'declared',
+          null,
+          (err, results) => {
+            t.equal(results.length, 2)
+            t.equal(results[0].value.content.type, 'post')
+            t.equal(results[1].value.content.type, 'post')
+            db.all(
+              prefixQuery,
+              0,
+              false,
+              false,
+              'declared',
+              null,
+              (err, results2) => {
+                t.equal(results2.length, 2)
+                t.equal(results2[0].value.content.type, 'post')
+                t.equal(results2[1].value.content.type, 'post')
+                t.end()
+              }
+            )
+          }
+        )
       })
     })
   })
@@ -138,27 +154,36 @@ prepareAndRunTest('Prefix index skips deleted records', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err1) => {
     addMsg(state.queue[1].value, raf, (err2) => {
       addMsg(state.queue[2].value, raf, (err3) => {
-        db.all(prefixQuery, 0, false, true, 'declared', (err4, offsets) => {
-          t.error(err4, 'no err4')
-          t.deepEqual(offsets, [0, 760])
-          raf.del(760, (err5) => {
-            t.error(err5, 'no err5')
-            db.all(
-              prefixQuery2,
-              0,
-              false,
-              false,
-              'declared',
-              (err6, results) => {
-                t.error(err6, 'no err6')
-                t.equal(results.length, 1)
-                t.equal(results[0].value.content.type, 'post')
-                t.equal(results[0].value.content.text, 'Testing!')
-                t.end()
-              }
-            )
-          })
-        })
+        db.all(
+          prefixQuery,
+          0,
+          false,
+          true,
+          'declared',
+          null,
+          (err4, offsets) => {
+            t.error(err4, 'no err4')
+            t.deepEqual(offsets, [0, 760])
+            raf.del(760, (err5) => {
+              t.error(err5, 'no err5')
+              db.all(
+                prefixQuery2,
+                0,
+                false,
+                false,
+                'declared',
+                null,
+                (err6, results) => {
+                  t.error(err6, 'no err6')
+                  t.equal(results.length, 1)
+                  t.equal(results[0].value.content.type, 'post')
+                  t.equal(results[0].value.content.text, 'Testing!')
+                  t.end()
+                }
+              )
+            })
+          }
+        )
       })
     })
   })
@@ -188,11 +213,19 @@ prepareAndRunTest('Prefix larger than actual value', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(channelQuery, 0, false, false, 'declared', (err, results) => {
-          t.equal(results.length, 1)
-          t.equal(results[0].value.content.text, 'First')
-          t.end()
-        })
+        db.all(
+          channelQuery,
+          0,
+          false,
+          false,
+          'declared',
+          null,
+          (err, results) => {
+            t.equal(results.length, 1)
+            t.equal(results[0].value.content.text, 'First')
+            t.end()
+          }
+        )
       })
     })
   })
@@ -222,12 +255,20 @@ prepareAndRunTest('Prefix equal falsy', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(channelQuery, 0, false, false, 'declared', (err, results) => {
-          t.equal(results.length, 2)
-          t.equal(results[0].value.content.text, 'Second')
-          t.equal(results[1].value.content.text, 'Third')
-          t.end()
-        })
+        db.all(
+          channelQuery,
+          0,
+          false,
+          false,
+          'declared',
+          null,
+          (err, results) => {
+            t.equal(results.length, 2)
+            t.equal(results[0].value.content.text, 'Second')
+            t.equal(results[1].value.content.text, 'Third')
+            t.end()
+          }
+        )
       })
     })
   })
@@ -287,36 +328,45 @@ prepareAndRunTest('Prefix equal', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(voteQuery, 0, false, false, 'declared', (err, results) => {
+        db.all(voteQuery, 0, false, false, 'declared', null, (err, results) => {
           t.equal(results.length, 1)
           t.equal(results[0].value.content.type, 'vote')
 
           db = jitdb(raf, path.join(dir, 'indexes' + name))
           db.onReady(() => {
             addMsg(state.queue[3].value, raf, (err, msg) => {
-              db.all(voteQuery, 0, false, false, 'declared', (err, results) => {
-                t.equal(results.length, 2)
+              db.all(
+                voteQuery,
+                0,
+                false,
+                false,
+                'declared',
+                null,
+                (err, results) => {
+                  t.equal(results.length, 2)
 
-                db = jitdb(raf, path.join(dir, 'indexes' + name))
-                db.onReady(() => {
-                  addMsg(state.queue[4].value, raf, (err, msg) => {
-                    db.all(
-                      voteQuery,
-                      0,
-                      false,
-                      false,
-                      'declared',
-                      (err, results) => {
-                        t.equal(results.length, 3)
-                        t.equal(results[0].value.content.type, 'vote')
-                        t.equal(results[1].value.content.type, 'vote')
-                        t.equal(results[2].value.content.type, 'vote')
-                        t.end()
-                      }
-                    )
+                  db = jitdb(raf, path.join(dir, 'indexes' + name))
+                  db.onReady(() => {
+                    addMsg(state.queue[4].value, raf, (err, msg) => {
+                      db.all(
+                        voteQuery,
+                        0,
+                        false,
+                        false,
+                        'declared',
+                        null,
+                        (err, results) => {
+                          t.equal(results.length, 3)
+                          t.equal(results[0].value.content.type, 'vote')
+                          t.equal(results[1].value.content.type, 'vote')
+                          t.equal(results[2].value.content.type, 'vote')
+                          t.end()
+                        }
+                      )
+                    })
                   })
-                })
-              })
+                }
+              )
             })
           })
         })
@@ -349,10 +399,18 @@ prepareAndRunTest('Prefix equal unknown value', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(authorQuery, 0, false, false, 'declared', (err, results) => {
-          t.equal(results.length, 0)
-          t.end()
-        })
+        db.all(
+          authorQuery,
+          0,
+          false,
+          false,
+          'declared',
+          null,
+          (err, results) => {
+            t.equal(results.length, 0)
+            t.end()
+          }
+        )
       })
     })
   })
@@ -383,7 +441,7 @@ prepareAndRunTest('Prefix map equal', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
+        db.all(typeQuery, 0, false, false, 'declared', null, (err, results) => {
           t.equal(results.length, 2)
           t.equal(results[0].value.content.type, 'post')
           t.equal(results[1].value.content.type, 'post')
@@ -420,7 +478,7 @@ prepareAndRunTest('Prefix offset', dir, (t, db, raf) => {
           },
         }
 
-        db.all(keyQuery, 0, false, false, 'declared', (err, results) => {
+        db.all(keyQuery, 0, false, false, 'declared', null, (err, results) => {
           t.equal(results.length, 1)
           t.equal(results[0].value.content.text, 'Testing 2!')
           t.end()
@@ -450,7 +508,7 @@ prepareAndRunTest('Prefix offset 1 on empty', dir, (t, db, raf) => {
       },
     }
 
-    db.all(rootQuery, 0, false, false, 'declared', (err, results) => {
+    db.all(rootQuery, 0, false, false, 'declared', null, (err, results) => {
       t.equal(results.length, 1)
       t.equal(results[0].value.content.text, 'Testing!')
       t.end()
@@ -502,6 +560,7 @@ prepareAndRunTest('Prefix delete', dir, (t, db, raf) => {
           false,
           false,
           'declared',
+          null,
           (err, results) => {
             t.equal(results.length, 2)
             t.equal(results[0].value.content.type, 'post')
@@ -518,6 +577,7 @@ prepareAndRunTest('Prefix delete', dir, (t, db, raf) => {
                 false,
                 false,
                 'declared',
+                null,
                 (err, answer) => {
                   t.equal(answer.results.length, 1)
                   t.equal(answer.results[0].value.content.text, 'Testing 2!')

--- a/test/query.js
+++ b/test/query.js
@@ -51,17 +51,25 @@ prepareAndRunTest('Multiple types', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
+        db.all(typeQuery, 0, false, false, 'declared', null, (err, results) => {
           t.equal(results.length, 2)
           t.equal(results[0].value.content.type, 'post')
           t.equal(results[1].value.content.type, 'post')
 
-          db.all(contactQuery, 0, false, false, 'declared', (err, results) => {
-            t.equal(results.length, 1)
-            t.equal(results[0].value.content.type, 'contact')
+          db.all(
+            contactQuery,
+            0,
+            false,
+            false,
+            'declared',
+            null,
+            (err, results) => {
+              t.equal(results.length, 1)
+              t.equal(results[0].value.content.type, 'contact')
 
-            t.end()
-          })
+              t.end()
+            }
+          )
         })
       })
     })
@@ -98,6 +106,7 @@ prepareAndRunTest('Top 1 multiple types', dir, (t, db, raf) => {
           true,
           false,
           'declared',
+          null,
           (err, { results }) => {
             t.equal(results.length, 1)
             t.equal(results[0].value.content.text, 'Testing 2!')
@@ -133,6 +142,7 @@ prepareAndRunTest('Limit -1', dir, (t, db, raf) => {
       true,
       false,
       'declared',
+      null,
       (err2, { results }) => {
         t.error(err2)
         t.equal(results.length, 0)
@@ -166,6 +176,7 @@ prepareAndRunTest('Limit 0', dir, (t, db, raf) => {
       true,
       false,
       'declared',
+      null,
       (err2, { results }) => {
         t.error(err2)
         t.equal(results.length, 0)
@@ -198,13 +209,21 @@ prepareAndRunTest('Includes', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err1, msg) => {
     addMsg(state.queue[1].value, raf, (err2, msg) => {
       addMsg(state.queue[2].value, raf, (err3, msg) => {
-        db.all(typeQuery, 0, false, false, 'declared', (err4, results) => {
-          t.error(err4)
-          t.equal(results.length, 2)
-          t.equal(results[0].value.content.text, '1st')
-          t.equal(results[1].value.content.text, '2nd')
-          t.end()
-        })
+        db.all(
+          typeQuery,
+          0,
+          false,
+          false,
+          'declared',
+          null,
+          (err4, results) => {
+            t.error(err4)
+            t.equal(results.length, 2)
+            t.equal(results[0].value.content.text, '1st')
+            t.equal(results[1].value.content.text, '2nd')
+            t.end()
+          }
+        )
       })
     })
   })
@@ -246,13 +265,21 @@ prepareAndRunTest('Includes and pluck', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err1, msg) => {
     addMsg(state.queue[1].value, raf, (err2, msg) => {
       addMsg(state.queue[2].value, raf, (err3, msg) => {
-        db.all(typeQuery, 0, false, false, 'declared', (err4, results) => {
-          t.error(err4)
-          t.equal(results.length, 2)
-          t.equal(results[0].value.content.text, '1st')
-          t.equal(results[1].value.content.text, '2nd')
-          t.end()
-        })
+        db.all(
+          typeQuery,
+          0,
+          false,
+          false,
+          'declared',
+          null,
+          (err4, results) => {
+            t.error(err4)
+            t.equal(results.length, 2)
+            t.equal(results[0].value.content.text, '1st')
+            t.equal(results[1].value.content.text, '2nd')
+            t.end()
+          }
+        )
       })
     })
   })
@@ -288,6 +315,7 @@ prepareAndRunTest('Paginate many pages', dir, (t, db, raf) => {
           false,
           false,
           'declared',
+          null,
           (err, { results }) => {
             t.equal(results.length, 1)
             t.equal(results[0].value.content.text, '1st')
@@ -298,6 +326,7 @@ prepareAndRunTest('Paginate many pages', dir, (t, db, raf) => {
               false,
               false,
               'declared',
+              null,
               (err, { results }) => {
                 t.equal(results.length, 1)
                 t.equal(results[0].value.content.text, '2nd')
@@ -308,6 +337,7 @@ prepareAndRunTest('Paginate many pages', dir, (t, db, raf) => {
                   false,
                   false,
                   'declared',
+                  null,
                   (err, { results }) => {
                     t.equal(results.length, 1)
                     t.equal(results[0].value.content.text, '3rd')
@@ -350,6 +380,7 @@ prepareAndRunTest('Paginate empty', dir, (t, db, raf) => {
         false,
         false,
         'declared',
+        null,
         (err3, { results }) => {
           t.error(err3)
           t.equal(results.length, 0)
@@ -390,6 +421,7 @@ prepareAndRunTest('Seq', dir, (t, db, raf) => {
           true,
           false,
           'declared',
+          null,
           (err, { results }) => {
             t.equal(results.length, 1)
             t.equal(results[0].value.content.text, 'Testing!')
@@ -425,6 +457,7 @@ prepareAndRunTest('Buffer', dir, (t, db, raf) => {
       true,
       false,
       'declared',
+      null,
       (err, { results }) => {
         t.equal(results.length, 1)
         t.equal(results[0].value.content.text, 'Testing!')
@@ -464,6 +497,7 @@ prepareAndRunTest('Undefined', dir, (t, db, raf) => {
           false,
           false,
           'declared',
+          null,
           (err, { results }) => {
             t.equal(results.length, 2)
             t.equal(results[0].value.content.text, 'Testing no root')
@@ -506,6 +540,7 @@ prepareAndRunTest('Null', dir, (t, db, raf) => {
           false,
           false,
           'declared',
+          null,
           (err, { results }) => {
             t.equal(results.length, 1)
             t.equal(results[0].value.content.text, 'Testing root null')
@@ -556,20 +591,19 @@ prepareAndRunTest('GT,GTE,LT,LTE', dir, (t, db, raf) => {
     addMsg(state.queue[1].value, raf, (err, dbMsg2) => {
       addMsg(state.queue[2].value, raf, (err, dbMsg3) => {
         addMsg(state.queue[3].value, raf, (err, dbMsg4) => {
-          db.all(filterQuery, 0, false, false, 'declared', (err, results) => {
-            t.error(err, 'no err')
-            t.equal(results.length, 3)
-            t.equal(results[0].value.content.text, '2')
+          db.all(
+            filterQuery,
+            0,
+            false,
+            false,
+            'declared',
+            null,
+            (err, results) => {
+              t.error(err, 'no err')
+              t.equal(results.length, 3)
+              t.equal(results[0].value.content.text, '2')
 
-            filterQuery.data[0].type = 'GTE'
-            // clone to force cache invalidation inside db.all:
-            filterQuery = Object.assign({}, filterQuery)
-            db.all(filterQuery, 0, false, false, 'declared', (err, results) => {
-              t.equal(results.length, 4)
-              t.equal(results[0].value.content.text, '1')
-
-              filterQuery.data[0].type = 'LT'
-              filterQuery.data[0].data.value = 3
+              filterQuery.data[0].type = 'GTE'
               // clone to force cache invalidation inside db.all:
               filterQuery = Object.assign({}, filterQuery)
               db.all(
@@ -578,11 +612,13 @@ prepareAndRunTest('GT,GTE,LT,LTE', dir, (t, db, raf) => {
                 false,
                 false,
                 'declared',
+                null,
                 (err, results) => {
-                  t.equal(results.length, 2)
+                  t.equal(results.length, 4)
                   t.equal(results[0].value.content.text, '1')
 
-                  filterQuery.data[0].type = 'LTE'
+                  filterQuery.data[0].type = 'LT'
+                  filterQuery.data[0].data.value = 3
                   // clone to force cache invalidation inside db.all:
                   filterQuery = Object.assign({}, filterQuery)
                   db.all(
@@ -591,13 +627,12 @@ prepareAndRunTest('GT,GTE,LT,LTE', dir, (t, db, raf) => {
                     false,
                     false,
                     'declared',
+                    null,
                     (err, results) => {
-                      t.equal(results.length, 3)
+                      t.equal(results.length, 2)
                       t.equal(results[0].value.content.text, '1')
 
-                      filterQuery.data[0].type = 'GT'
-                      filterQuery.data[0].data.indexName = 'timestamp'
-                      filterQuery.data[0].data.value = dbMsg1.value.timestamp
+                      filterQuery.data[0].type = 'LTE'
                       // clone to force cache invalidation inside db.all:
                       filterQuery = Object.assign({}, filterQuery)
                       db.all(
@@ -606,19 +641,39 @@ prepareAndRunTest('GT,GTE,LT,LTE', dir, (t, db, raf) => {
                         false,
                         false,
                         'declared',
+                        null,
                         (err, results) => {
                           t.equal(results.length, 3)
-                          t.equal(results[0].value.content.text, '2')
+                          t.equal(results[0].value.content.text, '1')
 
-                          t.end()
+                          filterQuery.data[0].type = 'GT'
+                          filterQuery.data[0].data.indexName = 'timestamp'
+                          filterQuery.data[0].data.value =
+                            dbMsg1.value.timestamp
+                          // clone to force cache invalidation inside db.all:
+                          filterQuery = Object.assign({}, filterQuery)
+                          db.all(
+                            filterQuery,
+                            0,
+                            false,
+                            false,
+                            'declared',
+                            null,
+                            (err, results) => {
+                              t.equal(results.length, 3)
+                              t.equal(results[0].value.content.text, '2')
+
+                              t.end()
+                            }
+                          )
                         }
                       )
                     }
                   )
                 }
               )
-            })
-          })
+            }
+          )
         })
       })
     })
@@ -649,14 +704,22 @@ prepareAndRunTest('GTE Zero', dir, (t, db, raf) => {
     addMsg(state.queue[1].value, raf, (err, dbMsg2) => {
       addMsg(state.queue[2].value, raf, (err, dbMsg3) => {
         addMsg(state.queue[3].value, raf, (err, dbMsg4) => {
-          db.all(filterQuery, 0, false, false, 'declared', (err, results) => {
-            t.equal(results.length, 4)
-            t.equal(results[0].value.content.text, '1')
-            t.equal(results[1].value.content.text, '2')
-            t.equal(results[2].value.content.text, '3')
-            t.equal(results[3].value.content.text, '4')
-            t.end()
-          })
+          db.all(
+            filterQuery,
+            0,
+            false,
+            false,
+            'declared',
+            null,
+            (err, results) => {
+              t.equal(results.length, 4)
+              t.equal(results[0].value.content.text, '1')
+              t.equal(results[1].value.content.text, '2')
+              t.equal(results[2].value.content.text, '3')
+              t.equal(results[3].value.content.text, '4')
+              t.end()
+            }
+          )
         })
       })
     })
@@ -702,6 +765,7 @@ prepareAndRunTest('Data offsets', dir, (t, db, raf) => {
           true,
           false,
           'declared',
+          null,
           (err, { results }) => {
             t.equal(results.length, 1)
             t.equal(results[0].value.content.text, 'Testing no root')
@@ -731,7 +795,7 @@ prepareAndRunTest('Data seqs simple', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(dataQuery, 0, false, false, 'declared', (err, results) => {
+        db.all(dataQuery, 0, false, false, 'declared', null, (err, results) => {
           t.equal(results.length, 2)
           t.equal(results[0].value.content.name, 'Test')
           t.equal(results[1].value.content.text, 'Testing no root')
@@ -781,6 +845,7 @@ prepareAndRunTest('Data seqs', dir, (t, db, raf) => {
           true,
           false,
           'declared',
+          null,
           (err, { results }) => {
             t.equal(results.length, 1)
             t.equal(results[0].value.content.text, 'Testing no root')
@@ -838,7 +903,7 @@ prepareAndRunTest('Multiple ands', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(allQuery, 0, false, false, 'declared', (err, results) => {
+        db.all(allQuery, 0, false, false, 'declared', null, (err, results) => {
           t.equal(results.length, 1)
           t.equal(results[0].value.content.text, 'Testing 2!')
           t.end()
@@ -911,7 +976,7 @@ prepareAndRunTest('Multiple ors', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(allQuery, 0, false, false, 'declared', (err, results) => {
+        db.all(allQuery, 0, false, false, 'declared', null, (err, results) => {
           t.equal(results.length, 2)
           t.equal(results[0].value.content.text, 'Testing!')
           t.equal(results[1].value.content.text, 'Testing 2!')
@@ -949,13 +1014,21 @@ prepareAndRunTest('Timestamp discontinuity', dir, (t, db, raf) => {
     addMsg(state.queue[0].value, raf, (err, m1) => {
       addMsg(state.queue[1].value, raf, (err, m2) => {
         addMsg(state.queue[2].value, raf, (err, m3) => {
-          db.all(authorQuery, 0, false, false, 'declared', (err, results) => {
-            t.equal(results.length, 3)
-            t.equal(results[0].value.content.text, '3rd', '3rd ok')
-            t.equal(results[1].value.content.text, '2nd', '2nd ok')
-            t.equal(results[2].value.content.text, '1st', '1st ok')
-            t.end()
-          })
+          db.all(
+            authorQuery,
+            0,
+            false,
+            false,
+            'declared',
+            null,
+            (err, results) => {
+              t.equal(results.length, 3)
+              t.equal(results[0].value.content.text, '3rd', '3rd ok')
+              t.equal(results[1].value.content.text, '2nd', '2nd ok')
+              t.equal(results[2].value.content.text, '1st', '1st ok')
+              t.end()
+            }
+          )
         })
       })
     })
@@ -992,7 +1065,7 @@ prepareAndRunTest('reindex corrupt indexes', dir, (t, db, raf) => {
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
       addMsg(state.queue[2].value, raf, (err, msg) => {
-        db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
+        db.all(typeQuery, 0, false, false, 'declared', null, (err, results) => {
           t.equal(results.length, 2)
 
           const dir = '/tmp/jitdb-query/indexesreindex corrupt indexes/'
@@ -1010,6 +1083,7 @@ prepareAndRunTest('reindex corrupt indexes', dir, (t, db, raf) => {
                     false,
                     false,
                     'declared',
+                    null,
                     (err, results) => {
                       t.equal(results.length, 2)
                       t.end()

--- a/test/reindex.js
+++ b/test/reindex.js
@@ -79,22 +79,30 @@ prepareAndRunTest('reindex seq offset', dir, (t, db, raf) => {
   }
 
   addThreeMessages(raf, () => {
-    db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
+    db.all(typeQuery, 0, false, false, 'declared', null, (err, results) => {
       t.equal(results.length, 2)
       t.equal(results[0].value.content.type, 'post')
       t.equal(results[1].value.content.type, 'post')
 
       db.reindex(0, () => {
-        db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
+        db.all(typeQuery, 0, false, false, 'declared', null, (err, results) => {
           t.equal(results.length, 2)
 
           const secondMsgOffset = 352
           db.reindex(secondMsgOffset, () => {
-            db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
-              t.equal(results.length, 2)
+            db.all(
+              typeQuery,
+              0,
+              false,
+              false,
+              'declared',
+              null,
+              (err, results) => {
+                t.equal(results.length, 2)
 
-              t.end()
-            })
+                t.end()
+              }
+            )
           })
         })
       })
@@ -116,13 +124,13 @@ prepareAndRunTest('reindex bitset', dir, (t, db, raf) => {
   }
 
   addThreeMessages(raf, () => {
-    db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
+    db.all(typeQuery, 0, false, false, 'declared', null, (err, results) => {
       t.equal(results.length, 1)
       t.equal(results[0].value.content.type, 'post')
 
       db.reindex(0, () => {
         removeFilter()
-        db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
+        db.all(typeQuery, 0, false, false, 'declared', null, (err, results) => {
           t.equal(results.length, 2)
           t.end()
         })
@@ -147,13 +155,13 @@ prepareAndRunTest('reindex prefix', dir, (t, db, raf) => {
   }
 
   addThreeMessages(raf, () => {
-    db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
+    db.all(typeQuery, 0, false, false, 'declared', null, (err, results) => {
       t.equal(results.length, 1)
       t.equal(results[0].value.content.type, 'post')
 
       db.reindex(0, () => {
         removeFilter()
-        db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
+        db.all(typeQuery, 0, false, false, 'declared', null, (err, results) => {
           t.equal(results.length, 2)
           t.end()
         })
@@ -179,13 +187,13 @@ prepareAndRunTest('reindex prefix map', dir, (t, db, raf) => {
   }
 
   addThreeMessages(raf, () => {
-    db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
+    db.all(typeQuery, 0, false, false, 'declared', null, (err, results) => {
       t.equal(results.length, 1)
       t.equal(results[0].value.content.type, 'post')
 
       db.reindex(0, () => {
         removeFilter()
-        db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
+        db.all(typeQuery, 0, false, false, 'declared', null, (err, results) => {
           t.equal(results.length, 2)
           t.end()
         })

--- a/test/seq-index-not-uptodate.js
+++ b/test/seq-index-not-uptodate.js
@@ -39,7 +39,7 @@ prepareAndRunTest('Ensure seq index is updated always', dir, (t, db, raf) => {
 
   addMsg(state.queue[0].value, raf, (err, msg) => {
     addMsg(state.queue[1].value, raf, (err, msg) => {
-      db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
+      db.all(typeQuery, 0, false, false, 'declared', null, (err, results) => {
         t.equal(results.length, 1)
         t.equal(results[0].value.content.type, 'post')
 
@@ -51,12 +51,20 @@ prepareAndRunTest('Ensure seq index is updated always', dir, (t, db, raf) => {
         }
 
         addMsg(state.queue[2].value, raf, (err, msg) => {
-          db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
-            t.equal(results.length, 2)
-            t.equal(results[0].value.content.type, 'post')
-            t.equal(results[1].value.content.type, 'post')
-            t.end()
-          })
+          db.all(
+            typeQuery,
+            0,
+            false,
+            false,
+            'declared',
+            null,
+            (err, results) => {
+              t.equal(results.length, 2)
+              t.equal(results[0].value.content.type, 'post')
+              t.equal(results[1].value.content.type, 'post')
+              t.end()
+            }
+          )
         })
       })
     })

--- a/test/slow-save.js
+++ b/test/slow-save.js
@@ -64,7 +64,7 @@ prepareAndRunTest('wip-index-save', dir, (t, db, raf) => {
       t.equal(results1.length, TOTAL)
 
       // Run some empty query to update the core indexes
-      db.all({}, 0, false, false, 'declared', (err2, results2) => {
+      db.all({}, 0, false, false, 'declared', null, (err2, results2) => {
         t.error(err2, 'indexed core with ' + TOTAL + ' msgs with no error')
         t.equal(results2.length, TOTAL)
 
@@ -103,14 +103,22 @@ prepareAndRunTest('wip-index-save', dir, (t, db, raf) => {
         }, 65e3)
 
         // Run an actual query to check if it saves every 1min
-        db.all(typeQuery, 0, false, false, 'declared', (err3, results3) => {
-          t.error(err3, 'indexed ' + TOTAL + ' msgs no error')
-          t.equal(results3.length, TOTAL)
+        db.all(
+          typeQuery,
+          0,
+          false,
+          false,
+          'declared',
+          null,
+          (err3, results3) => {
+            t.error(err3, 'indexed ' + TOTAL + ' msgs no error')
+            t.equal(results3.length, TOTAL)
 
-          t.true(savedAfter1min, 'saved after 1 min')
-          rimraf.sync(dir) // this folder is quite large, lets save space
-          t.end()
-        })
+            t.true(savedAfter1min, 'saved after 1 min')
+            rimraf.sync(dir) // this folder is quite large, lets save space
+            t.end()
+          }
+        )
       })
     })
   )


### PR DESCRIPTION
# Background

@mixmix was working on adding [an option](https://gitlab.com/ahau/lib/ssb-crut/-/merge_requests/28) to crut list where you would get results ordered by updateTime. We would like to avoid running through all the results (db1 has to do this) in order to display say the latest 5 buttcasts. For this what we really need is a group by operator similar to what you have in a normal database. So this is quite general, you could also use this functionality to show the latest post for each feed. I tried modelling this similar to the seek function. This means we still have to run through results to extract what we need, but since we are working directly on the bipf data, it's not really that bad. This can still be combined with regular where filtering and when used with limit, it will stop once enough results are found.