### PR TITLE
use binary search to get seq from offset

### DIFF
--- a/index.js
+++ b/index.js
@@ -841,8 +841,8 @@ module.exports = function (log, indexesPath) {
     const seqs = []
     opOffsets.sort((x, y) => x - y)
     const opOffsetsLen = opOffsets.length
-    const { tarr } = indexes['seq']
-    for (let seq = 0, len = tarr.length; seq < len; ++seq) {
+    const { tarr, count } = indexes['seq']
+    for (let seq = 0; seq < count; ++seq) {
       if (bsb.eq(opOffsets, tarr[seq]) !== -1) seqs.push(seq)
       if (seqs.length === opOffsetsLen) break
     }
@@ -1513,7 +1513,7 @@ module.exports = function (log, indexesPath) {
       prevOffset = indexes['seq'].tarr[seq - 1]
     }
 
-    if (prevOffset === 0 && seq === indexes['seq'].tarr.length) {
+    if (prevOffset === 0 && seq === indexes['seq'].count) {
       // not found
       seq = 1
     }


### PR DESCRIPTION
## Context

I'm preparing for #199 and one thing I realized is that I'll need a quick way of getting the seq from any given offset, e.g. during compaction there is going to be `unshiftedOffset` and I'd like to discover `unshiftedSeq`.

## Problem

We don't have a helper function for that and currently we're just doing a linear for-loop to look for the offset.

Another problem is that the "end" of the for-loop is `tarr.length`, which I think is wrong because the tarr grows much more than the `count` does (like it doubles in size every time it "grows" but most of it is still unused). Instead we need to use `index.count`.

## Solution

Introduce `getSeqFromOffset` that does a binary search and uses `indexes['seq'].count` as the end marker.

This should also have a performance improvement for those cases when the jitdb indexes are many and large but we just need to update the tip of the index. This way we can avoid scanning the whole index in `O(n)` and can do `O(log n)`. I'm not sure we have any benchmark for this but should be a pretty common thing to happen in production.