### PR TITLE
dont prune old fields from status object

### DIFF
--- a/test/add.js
+++ b/test/add.js
@@ -202,7 +202,7 @@ prepareAndRunTest('Update index', dir, (t, db, raf) => {
   })
 })
 
-prepareAndRunTest('obsolete status parts disappear', dir, (t, db, raf) => {
+prepareAndRunTest('old status fields are never pruned', dir, (t, db, raf) => {
   let post = { type: 'post', text: 'Testing' }
 
   let state = validate.initial()
@@ -257,7 +257,7 @@ prepareAndRunTest('obsolete status parts disappear', dir, (t, db, raf) => {
             db.paginate(aboutQuery, 0, 1, false, false, 'declared', () => {
               t.pass(JSON.stringify(db.status.value))
               t.ok(db.status.value['seq'])
-              t.notOk(db.status.value['type_post'])
+              t.ok(db.status.value['type_post'], 'old NOT pruned')
               t.ok(db.status.value['type_about'])
               t.end()
             })


### PR DESCRIPTION
## Context

Some Manyverse users have been complaining that the progress bar for "preparing database" should never decrease, it should always monotonically increase.

(By the way, this PR is part of my Manyverse work, not part of the log compaction grant)

## Problem

The `pruneStatus()` functionality in `./status.js` was originally intended to align with the "JIT" nature of JITDB, but in reality it doesn't help at all, because it means that certain fields sometimes disappear (due to `pruneStatus()`) and then appear (due to the index being updated), making the overall progress bar calculation change a lot.

## Solution

The "JIT" nature should only be per **session**, that is, the indexes that are loaded into memory in the current session should have, respectively, their `status` fields always available.

I removed `pruneStatus()` and updated tests accordingly.