### PR TITLE
add prepare() API to bypass laziness

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,6 +567,13 @@ will be the messages directly.
 
 Similar to `all` except it does not fetch records from the log, it only responds with a number that tells the total amount of records matching the operation.
 
+### prepare(operation, cb)
+
+Ensures that the indexes in the `operation` are up-to-date by creating or
+updating them, if necessary. This is not a query, as it won't return any
+results. When done, the callback `cb` is just called with the "duration" of
+index preparation as the second argument.
+
 ### live(operation, cb)
 
 Will setup a pull stream and this in `cb`. The pull stream will emit

--- a/index.js
+++ b/index.js
@@ -1423,6 +1423,17 @@ module.exports = function (log, indexesPath) {
     })
   }
 
+  function prepare(operation, cb) {
+    onReady(() => {
+      const start = Date.now()
+      executeOperation(operation, (err) => {
+        if (err) return cb(err)
+        const duration = Date.now() - start
+        cb(null, duration)
+      })
+    })
+  }
+
   // live will return new messages as they enter the log
   // can be combined with a normal all or paginate first
   function live(op) {
@@ -1566,6 +1577,7 @@ module.exports = function (log, indexesPath) {
     paginate,
     all,
     count,
+    prepare,
     live,
     status: status.obv,
     reindex,

--- a/test/add.js
+++ b/test/add.js
@@ -451,10 +451,12 @@ prepareAndRunTest('prepare an index', dir, (t, db, raf) => {
       addMsg(q.value, raf, cb)
     }),
     push.collect((err, results) => {
+      t.notOk(db.indexes['type_post'])
       db.prepare(typeQuery, (err, duration) => {
         t.error(err, 'no error')
         t.equals(typeof duration, 'number')
         t.ok(duration)
+        t.ok(db.indexes['type_post'])
         db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
           t.equal(results.length, 1000)
           t.end()


### PR DESCRIPTION
## Context

Some indexes in Manyverse are always required but the index only begins building after leveldb indexes (which are eager) are built. This may cause some sudden jumps backwards in the progress bar.

## Problem

For indexes that we know are always required, we need to have a way of turning off laziness, so to trigger their building as soon as possible. This also helps to have these indexes registered in `status`.

## Solution

New API `prepare()` which "warms up" the index. See the readme diff for a description.