### PR TITLE
add API resetStatus()

### DIFF
--- a/index.js
+++ b/index.js
@@ -1590,6 +1590,7 @@ module.exports = function (log, indexesPath) {
     prepare,
     live,
     status: status.obv,
+    resetStatus: status.reset,
     reindex,
 
     // testing

--- a/status.js
+++ b/status.js
@@ -5,14 +5,23 @@
 const Obv = require('obz')
 
 module.exports = function Status() {
-  const indexesStatus = {}
-  const indexesLastTime = {}
+  let indexesStatus = {}
   const obv = Obv()
   obv.set(indexesStatus)
   const EMIT_INTERVAL = 1000 // ms
   let i = 0
   let iTimer = 0
   let timer = null
+
+  function reset() {
+    indexesStatus = {}
+    if (timer) {
+      clearInterval(timer)
+      timer = null
+      i = iTimer = 0
+    }
+    obv.set(indexesStatus)
+  }
 
   function setTimer() {
     // Turn on
@@ -31,12 +40,10 @@ module.exports = function Status() {
   }
 
   function batchUpdate(indexes, names) {
-    const now = Date.now()
     for (const indexName of names) {
       const previous = indexesStatus[indexName] || -Infinity
       if (indexes[indexName].offset > previous) {
         indexesStatus[indexName] = indexes[indexName].offset
-        indexesLastTime[indexName] = now
       }
     }
 
@@ -50,6 +57,7 @@ module.exports = function Status() {
 
   return {
     obv,
+    reset,
     batchUpdate,
   }
 }

--- a/test/add.js
+++ b/test/add.js
@@ -202,7 +202,7 @@ prepareAndRunTest('Update index', dir, (t, db, raf) => {
   })
 })
 
-prepareAndRunTest('old status fields are never pruned', dir, (t, db, raf) => {
+prepareAndRunTest('status is pruned only on reset()', dir, (t, db, raf) => {
   let post = { type: 'post', text: 'Testing' }
 
   let state = validate.initial()
@@ -259,6 +259,11 @@ prepareAndRunTest('old status fields are never pruned', dir, (t, db, raf) => {
               t.ok(db.status.value['seq'])
               t.ok(db.status.value['type_post'], 'old NOT pruned')
               t.ok(db.status.value['type_about'])
+
+              db.resetStatus()
+              t.notOk(db.status.value['seq'])
+              t.notOk(db.status.value['type_post'])
+              t.notOk(db.status.value['type_about'])
               t.end()
             })
           })


### PR DESCRIPTION
## Context

Continuing from https://github.com/ssb-ngi-pointer/ssb-db2/pull/321, now progress bars are predictable in Manyverse, but another problem came up.

**After** the progress bar reaches 100%, it fades away. And then, when a new message is replicated from peers, the progress bar **re-appears** but stays **stuck** at 100% (well, technically it's something like 99.99999). But clearly stuck, forever.

## Problem

Now I remember why we had `pruneStatus()` in the first place: it was to prevent JIT "sessions" from mixing their stats with each other.

The current problem is because `prepare()` runs only once, it builds the indexes initially, but it doesn't rebuild them for future messages replicated because, well, JIT.

As an example, suppose all indexes have built, and the progress is at exactly 100%, and the progress bar disappears. Then, a new message of type `'vote'` comes in, but the index for messages of type `'pub'` stays stuck at the previous offset, because there's no query in this scenario that demands `pub` messages. The `status` object will thus reflect these numbers, and the [progress bar calculation](https://github.com/ssb-ngi-pointer/ssb-db2/blob/994cb7b1e8aade81cbf4e98175fe14c6120a583f/db.js#L145) will remain stuck at something like 99.9999

## Solution

I considered that `prepare()` should be live, but then this would mean we are keeping all JIT indexes always up-to-date even if we don't need to. Not so JIT.

Instead, what I think will work best is to allow the `status` object in JITDB to be reset manually. Then ssb-db2 (I'll make a follow up PR) will reset JITDB's `status` numbers every time the progress bar calculation reaches exactly 100%.

Another way of thinking about this is that each "session" end when the progress reaches 100%, and then next "session" may be triggered by the building of other indexes than in the first session.