### PR TITLE
Improve status calculation and teardown

### DIFF
--- a/index.js
+++ b/index.js
@@ -1598,7 +1598,6 @@ module.exports = function (log, indexesPath) {
     prepare,
     live,
     status: status.obv,
-    resetStatus: status.reset,
     reindex,
 
     // testing

--- a/index.js
+++ b/index.js
@@ -653,7 +653,7 @@ module.exports = function (log, indexesPath) {
     const logstreamId = Math.ceil(Math.random() * 1000)
     debug(`log.stream #${logstreamId} started, to create indexes ${waitingKey}`)
     status.update(indexes, coreIndexNames)
-    status.update(indexes, newIndexNames)
+    status.update(newIndexes, newIndexNames)
 
     log.stream({}).pipe({
       paused: false,

--- a/status.js
+++ b/status.js
@@ -14,16 +14,6 @@ module.exports = function Status() {
   let timer = null
   const activeIndexNames = new Set()
 
-  function reset() {
-    indexesStatus = {}
-    if (timer) {
-      clearInterval(timer)
-      timer = null
-      i = iTimer = 0
-    }
-    obv.set(indexesStatus)
-  }
-
   function setTimer() {
     // Turn on
     timer = setInterval(() => {
@@ -77,7 +67,6 @@ module.exports = function Status() {
 
   return {
     obv,
-    reset,
     done,
     update,
   }

--- a/test/add.js
+++ b/test/add.js
@@ -259,11 +259,6 @@ prepareAndRunTest('status is pruned only on reset()', dir, (t, db, raf) => {
               t.ok(db.status.value['seq'])
               t.ok(db.status.value['type_post'], 'old NOT pruned')
               t.ok(db.status.value['type_about'])
-
-              db.resetStatus()
-              t.notOk(db.status.value['seq'])
-              t.notOk(db.status.value['type_post'])
-              t.notOk(db.status.value['type_about'])
               t.end()
             })
           })


### PR DESCRIPTION
As you may have guessed, I worked on this all day. (Context https://github.com/ssb-ngi-pointer/jitdb/pull/204 and https://github.com/ssb-ngi-pointer/ssb-db2/pull/322)

I tried all sorts of things, and I was coding directly in the Manyverse node_modules, so the approach I have in this PR has already been tested in Manyverse, both with ssb-fixtures and with real production data.

The summary is:

`status.js` (not `index.js`) needs to keep track of the indexes being updated, and once **all** of _those_ are done, then reset the status. The concept of a "progress bar session" exists in `status.js`, not in `index.js`. 

This was tricky because sometimes `index.js` "ended" processing all indexes, only to immediately start processing _another_ set of indexes, so we couldn't rely on that "end" event.

Additionally, I removed the status update from `executeOperation` because that was the wrong spot: `paginate()` calls `executeOperation` many times even when the indexes are already built, so we don't want to trigger status for those cases. So I moved it to the beginning of prepare().