### PR TITLE
Improve performance of query when seq is far behind log

### DIFF
--- a/index.js
+++ b/index.js
@@ -644,10 +644,14 @@ module.exports = function (log, indexesPath) {
         const index = newIndexes[indexName]
         if (doneIndexing) indexes[indexName] = index
         index.offset = offset
-        done(() => {
-          saveIndex(indexName, index, count)
-        })
       }
+
+      done(() => {
+        for (var indexName in newIndexes) {
+          const index = newIndexes[indexName]
+          saveIndex(indexName, index, count)
+        }
+      })
     }
 
     const logstreamId = Math.ceil(Math.random() * 1000)

--- a/index.js
+++ b/index.js
@@ -1092,9 +1092,6 @@ module.exports = function (log, indexesPath) {
       // kick-start this chain with a dummy null value
       push.values([null]),
 
-      // ensure that the seq->offset index is synchronized with the log
-      push.asyncMap((_, next) => ensureSeqIndexSync(next)),
-
       // load lazy indexes, if any
       push.asyncMap((_, next) => {
         const lazyIdxNames = detectLazyIndexesUsed(operation)
@@ -1116,6 +1113,9 @@ module.exports = function (log, indexesPath) {
         debug('missing indexes: %o', opsMissingIdx)
         createIndexes(opsMissingIdx, next)
       }),
+
+      // ensure that the seq->offset index is synchronized with the log
+      push.asyncMap((_, next) => ensureSeqIndexSync(next)),
 
       // get bitset for the input operation, and cache it
       push.asyncMap((_, next) => {

--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "ssb-keys": "^8.1.0",
     "ssb-ref": "^2.14.3",
     "ssb-validate": "^4.1.1",
+    "tap-arc": "^0.3.4",
     "tap-bail": "^1.0.0",
-    "tap-arc": "^0.1.2",
     "tape": "^5.2.2"
   },
   "scripts": {


### PR DESCRIPTION
I noticed this when doing a query: first jitdb updates seq and only after that, it updates what is needed for the query. There is an assumption that seq is in sync with the log after running a query, but instead of eagerly updated only `seq` index and then the rest. Why not try updating the indexes we need and only after that `seq` if needed. In most cases the `seq` update will then be a no op.

Running my normal 1GB query on empty db this is 15.7s compared to 17.6s before. I know this is a bit of a worst case example and in most real cases the difference won't be very big as `seq` is often very close to being in sync with the log because it is updated on any query.