### PR TITLE
pValue

### DIFF
--- a/index.js
+++ b/index.js
@@ -330,8 +330,7 @@ module.exports = function (log, indexesPath) {
   }
 
   function checkComparison(op, buffer) {
-    let pValue = 0
-    pValue = bipf.seekKey(buffer, pValue, B_VALUE)
+    const pValue = bipf.seekKey(buffer, 0, B_VALUE)
 
     if (op.data.indexName === 'timestamp') {
       const timestamp = seekMinTimestamp(buffer, pValue)
@@ -540,8 +539,7 @@ module.exports = function (log, indexesPath) {
           return
         }
 
-        let pValue = 0
-        pValue = bipf.seekKey(buffer, pValue, B_VALUE)
+        const pValue = bipf.seekKey(buffer, 0, B_VALUE)
 
         if (updateTimestampIndex(seq, offset, buffer, pValue))
           updatedTimestampIndex = true
@@ -675,8 +673,7 @@ module.exports = function (log, indexesPath) {
           return
         }
 
-        let pValue = 0
-        pValue = bipf.seekKey(buffer, pValue, B_VALUE)
+        const pValue = bipf.seekKey(buffer, 0, B_VALUE)
 
         if (updateTimestampIndex(seq, offset, buffer, pValue))
           updatedTimestampIndex = true
@@ -885,9 +882,7 @@ module.exports = function (log, indexesPath) {
     function checker(value) {
       if (!value) return false // deleted
 
-      let pValue = 0
-      pValue = bipf.seekKey(value, pValue, B_VALUE)
-
+      const pValue = bipf.seekKey(value, 0, B_VALUE)
       const fieldStart = seek(value, 0, pValue)
 
       if (target) return bipf.compare(value, fieldStart, target, 0) === 0
@@ -1155,8 +1150,7 @@ module.exports = function (log, indexesPath) {
   }
 
   function isValueOk(ops, value, isOr) {
-    let pValue = 0
-    pValue = bipf.seekKey(value, pValue, B_VALUE)
+    const pValue = bipf.seekKey(value, 0, B_VALUE)
 
     for (let i = 0; i < ops.length; ++i) {
       const op = ops[i]


### PR DESCRIPTION
I was wondering if we could do better on initial sync. #206 started out as that. That PR changed 1 initial jitdb query from around 17s to 15 something. Then I started wondering if we could do more and found that doing these extracting values (seq, timestamp, sequence) was significant. Meaning not only what we are looking for (opData.seek), but also the base values. Then I started playing around and found that actually finding the position of value inside the buffer is quite significant, so I refactored the code to get that once and pass that in. Note seekFromDesc allows a start (defaults to 0) and because of that we need 3 parameters to the seek function. I changed the seekers in ssb-db2 and now things are down to around 11s. This is on my laptop when it is not plugged in. Plugged in we are down to **7s** :-)

This PR is against #206, I'll change that once we know about that PR.