### PR TITLE
use bipf 1.6.0 seekKeyCached

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,6 @@ module.exports = function (log, indexesPath) {
 
   const B_TIMESTAMP = Buffer.from('timestamp')
   const B_SEQUENCE = Buffer.from('sequence')
-  const B_VALUE = Buffer.from('value')
 
   function loadIndexes(cb) {
     function parseIndexes(err, files) {
@@ -260,14 +259,14 @@ module.exports = function (log, indexesPath) {
   function seekMinTimestamp(buffer) {
     const pTimestamp = bipf.seekKey(buffer, 0, B_TIMESTAMP)
     const arrivalTimestamp = bipf.decode(buffer, pTimestamp)
-    const pValue = bipf.seekKeyCached(buffer, 0, B_VALUE)
+    const pValue = bipf.seekKeyCached(buffer, 0, 'value')
     const pValueTimestamp = bipf.seekKey(buffer, pValue, B_TIMESTAMP)
     const declaredTimestamp = bipf.decode(buffer, pValueTimestamp)
     return Math.min(arrivalTimestamp, declaredTimestamp)
   }
 
   function seekSequence(buffer) {
-    const pValue = bipf.seekKeyCached(buffer, 0, B_VALUE)
+    const pValue = bipf.seekKeyCached(buffer, 0, 'value')
     const p = bipf.seekKey(buffer, pValue, B_SEQUENCE)
     return bipf.decode(buffer, p)
   }

--- a/index.js
+++ b/index.js
@@ -82,9 +82,6 @@ module.exports = function (log, indexesPath) {
     else waiting.push(cb)
   }
 
-  const B_TIMESTAMP = Buffer.from('timestamp')
-  const B_SEQUENCE = Buffer.from('sequence')
-
   function loadIndexes(cb) {
     function parseIndexes(err, files) {
       push(
@@ -256,18 +253,20 @@ module.exports = function (log, indexesPath) {
     }
   }
 
+  const B_TIMESTAMP = Buffer.from('timestamp')
+
   function seekMinTimestamp(buffer) {
     const pTimestamp = bipf.seekKey(buffer, 0, B_TIMESTAMP)
     const arrivalTimestamp = bipf.decode(buffer, pTimestamp)
     const pValue = bipf.seekKeyCached(buffer, 0, 'value')
-    const pValueTimestamp = bipf.seekKey(buffer, pValue, B_TIMESTAMP)
+    const pValueTimestamp = bipf.seekKeyCached(buffer, pValue, 'timestamp')
     const declaredTimestamp = bipf.decode(buffer, pValueTimestamp)
     return Math.min(arrivalTimestamp, declaredTimestamp)
   }
 
   function seekSequence(buffer) {
     const pValue = bipf.seekKeyCached(buffer, 0, 'value')
-    const p = bipf.seekKey(buffer, pValue, B_SEQUENCE)
+    const p = bipf.seekKeyCached(buffer, pValue, 'sequence')
     return bipf.decode(buffer, p)
   }
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "atomic-file-rw": "^0.2.1",
     "binary-search-bounds": "^2.0.4",
-    "bipf": "^1.6.0",
+    "bipf": "^1.6.1",
     "crc": "3.6.0",
     "debug": "^4.2.0",
     "fastpriorityqueue": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "atomic-file-rw": "^0.2.1",
     "binary-search-bounds": "^2.0.4",
-    "bipf": "^1.5.4",
+    "bipf": "^1.6.0",
     "crc": "3.6.0",
     "debug": "^4.2.0",
     "fastpriorityqueue": "^0.7.1",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -4,86 +4,72 @@
 
 const bipf = require('bipf')
 
-const B_KEY = Buffer.from('key')
-const B_VALUE = Buffer.from('value')
-const B_VOTE = Buffer.from('vote')
-const B_LINK = Buffer.from('link')
-const B_AUTHOR = Buffer.from('author')
-const B_CONTENT = Buffer.from('content')
-const B_TYPE = Buffer.from('type')
-const B_ROOT = Buffer.from('root')
-const B_META = Buffer.from('meta')
-const B_ANIMALS = Buffer.from('animals')
-const B_WORD = Buffer.from('word')
-const B_PRIVATE = Buffer.from('private')
-const B_CHANNEL = Buffer.from('channel')
-
 module.exports = {
   toBipf(value) {
     return bipf.allocAndEncode(value)
   },
 
   seekKey(buffer) {
-    return bipf.seekKey(buffer, 0, B_KEY)
+    return bipf.seekKey(buffer, 0, 'key')
   },
 
   seekAuthor(buffer) {
-    const pValue = bipf.seekKeyCached(buffer, 0, B_VALUE)
+    const pValue = bipf.seekKeyCached(buffer, 0, 'value')
     if (pValue < 0) return
-    return bipf.seekKey(buffer, pValue, B_AUTHOR)
+    return bipf.seekKey(buffer, pValue, 'author')
   },
 
   seekVoteLink(buffer) {
-    const pValue = bipf.seekKeyCached(buffer, 0, B_VALUE)
+    const pValue = bipf.seekKeyCached(buffer, 0, 'value')
     if (pValue < 0) return
-    const pValueContent = bipf.seekKeyCached(buffer, pValue, B_CONTENT)
+    const pValueContent = bipf.seekKeyCached(buffer, pValue, 'content')
     if (pValueContent < 0) return
-    const pValueContentVote = bipf.seekKey(buffer, pValueContent, B_VOTE)
+    const pValueContentVote = bipf.seekKey(buffer, pValueContent, 'vote')
     if (pValueContentVote < 0) return
-    return bipf.seekKey(buffer, pValueContentVote, B_LINK)
+    return bipf.seekKey(buffer, pValueContentVote, 'link')
   },
 
   seekType(buffer) {
-    const pValue = bipf.seekKeyCached(buffer, 0, B_VALUE)
+    const pValue = bipf.seekKeyCached(buffer, 0, 'value')
     if (pValue < 0) return
-    const pValueContent = bipf.seekKeyCached(buffer, pValue, B_CONTENT)
+    const pValueContent = bipf.seekKeyCached(buffer, pValue, 'content')
     if (pValueContent < 0) return
-    return bipf.seekKey(buffer, pValueContent, B_TYPE)
+    return bipf.seekKey(buffer, pValueContent, 'type')
   },
 
   seekAnimals(buffer) {
-    const pValue = bipf.seekKeyCached(buffer, 0, B_VALUE)
+    const pValue = bipf.seekKeyCached(buffer, 0, 'value')
     if (pValue < 0) return
-    const pValueContent = bipf.seekKeyCached(buffer, pValue, B_CONTENT)
+    const pValueContent = bipf.seekKeyCached(buffer, pValue, 'content')
     if (pValueContent < 0) return
-    return bipf.seekKey(buffer, pValueContent, B_ANIMALS)
+    return bipf.seekKey(buffer, pValueContent, 'animals')
   },
 
   pluckWord(buffer, start) {
-    return bipf.seekKey(buffer, start, B_WORD)
+    return bipf.seekKey(buffer, start, 'word')
   },
 
   seekRoot(buffer) {
-    const pValue = bipf.seekKeyCached(buffer, 0, B_VALUE)
+    const pValue = bipf.seekKeyCached(buffer, 0, 'value')
     if (pValue < 0) return
-    const pValueContent = bipf.seekKeyCached(buffer, pValue, B_CONTENT)
+    const pValueContent = bipf.seekKeyCached(buffer, pValue, 'content')
     if (pValueContent < 0) return
-    return bipf.seekKey(buffer, pValueContent, B_ROOT)
+    return bipf.seekKey(buffer, pValueContent, 'root')
   },
 
   seekPrivate(buffer) {
-    const pValue = bipf.seekKeyCached(buffer, 0, B_VALUE)
+    const pValue = bipf.seekKeyCached(buffer, 0, 'value')
     if (pValue < 0) return
-    const pValueMeta = bipf.seekKeyCached(buffer, pValue, B_META)
+    const pValueMeta = bipf.seekKeyCached(buffer, pValue, 'meta')
     if (pValueMeta < 0) return
-    return bipf.seekKey(buffer, pValueMeta, B_PRIVATE)
+    return bipf.seekKey(buffer, pValueMeta, 'private')
   },
 
   seekChannel(buffer) {
-    const pValue = bipf.seekKeyCached(buffer, 0, B_VALUE)
+    const pValue = bipf.seekKeyCached(buffer, 0, 'value')
     if (pValue < 0) return
-    const pValueContent = bipf.seekKeyCached(buffer, pValue, B_CONTENT)
+    const pValueContent = bipf.seekKeyCached(buffer, pValue, 'content')
     if (pValueContent < 0) return
-    return bipf.seekKey(buffer, pValueContent, B_CHANNEL)
+    return bipf.seekKey(buffer, pValueContent, 'channel')
   },
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -19,84 +19,71 @@ const B_PRIVATE = Buffer.from('private')
 const B_CHANNEL = Buffer.from('channel')
 
 module.exports = {
-  toBipf: function (value) {
+  toBipf(value) {
     return bipf.allocAndEncode(value)
   },
 
-  seekKey: function (buffer) {
-    var p = 0 // note you pass in p!
-    return bipf.seekKey(buffer, p, B_KEY)
+  seekKey(buffer) {
+    return bipf.seekKey(buffer, 0, B_KEY)
   },
 
-  seekAuthor: function (buffer) {
-    var p = 0 // note you pass in p!
-    p = bipf.seekKey(buffer, p, B_VALUE)
-
-    if (~p) return bipf.seekKey(buffer, p, B_AUTHOR)
+  seekAuthor(buffer) {
+    const pValue = bipf.seekKeyCached(buffer, 0, B_VALUE)
+    if (pValue < 0) return
+    return bipf.seekKey(buffer, pValue, B_AUTHOR)
   },
 
-  seekVoteLink: function (buffer) {
-    var p = 0 // note you pass in p!
-    p = bipf.seekKey(buffer, p, B_VALUE)
-    if (!~p) return
-    p = bipf.seekKey(buffer, p, B_CONTENT)
-    if (!~p) return
-    p = bipf.seekKey(buffer, p, B_VOTE)
-    if (!~p) return
-    return bipf.seekKey(buffer, p, B_LINK)
+  seekVoteLink(buffer) {
+    const pValue = bipf.seekKeyCached(buffer, 0, B_VALUE)
+    if (pValue < 0) return
+    const pValueContent = bipf.seekKeyCached(buffer, pValue, B_CONTENT)
+    if (pValueContent < 0) return
+    const pValueContentVote = bipf.seekKey(buffer, pValueContent, B_VOTE)
+    if (pValueContentVote < 0) return
+    return bipf.seekKey(buffer, pValueContentVote, B_LINK)
   },
 
-  seekType: function (buffer) {
-    var p = 0 // note you pass in p!
-    p = bipf.seekKey(buffer, p, B_VALUE)
-
-    if (~p) {
-      p = bipf.seekKey(buffer, p, B_CONTENT)
-      if (~p) return bipf.seekKey(buffer, p, B_TYPE)
-    }
+  seekType(buffer) {
+    const pValue = bipf.seekKeyCached(buffer, 0, B_VALUE)
+    if (pValue < 0) return
+    const pValueContent = bipf.seekKeyCached(buffer, pValue, B_CONTENT)
+    if (pValueContent < 0) return
+    return bipf.seekKey(buffer, pValueContent, B_TYPE)
   },
 
-  seekAnimals: function (buffer) {
-    var p = 0 // note you pass in p!
-    p = bipf.seekKey(buffer, p, B_VALUE)
-    if (!~p) return
-    p = bipf.seekKey(buffer, p, B_CONTENT)
-    if (!~p) return
-    return bipf.seekKey(buffer, p, B_ANIMALS)
+  seekAnimals(buffer) {
+    const pValue = bipf.seekKeyCached(buffer, 0, B_VALUE)
+    if (pValue < 0) return
+    const pValueContent = bipf.seekKeyCached(buffer, pValue, B_CONTENT)
+    if (pValueContent < 0) return
+    return bipf.seekKey(buffer, pValueContent, B_ANIMALS)
   },
 
-  pluckWord: function (buffer, start) {
-    var p = start
-    return bipf.seekKey(buffer, p, B_WORD)
+  pluckWord(buffer, start) {
+    return bipf.seekKey(buffer, start, B_WORD)
   },
 
-  seekRoot: function (buffer) {
-    var p = 0 // note you pass in p!
-    p = bipf.seekKey(buffer, p, B_VALUE)
-
-    if (~p) {
-      p = bipf.seekKey(buffer, p, B_CONTENT)
-      if (~p) return bipf.seekKey(buffer, p, B_ROOT)
-    }
+  seekRoot(buffer) {
+    const pValue = bipf.seekKeyCached(buffer, 0, B_VALUE)
+    if (pValue < 0) return
+    const pValueContent = bipf.seekKeyCached(buffer, pValue, B_CONTENT)
+    if (pValueContent < 0) return
+    return bipf.seekKey(buffer, pValueContent, B_ROOT)
   },
 
-  seekPrivate: function (buffer) {
-    var p = 0 // note you pass in p!
-    p = bipf.seekKey(buffer, p, B_VALUE)
-
-    if (~p) {
-      p = bipf.seekKey(buffer, p, B_META)
-      if (~p) return bipf.seekKey(buffer, p, B_PRIVATE)
-    }
+  seekPrivate(buffer) {
+    const pValue = bipf.seekKeyCached(buffer, 0, B_VALUE)
+    if (pValue < 0) return
+    const pValueMeta = bipf.seekKeyCached(buffer, pValue, B_META)
+    if (pValueMeta < 0) return
+    return bipf.seekKey(buffer, pValueMeta, B_PRIVATE)
   },
 
-  seekChannel: function (buffer) {
-    var p = 0 // note you pass in p!
-    p = bipf.seekKey(buffer, p, B_VALUE)
-
-    if (~p) {
-      p = bipf.seekKey(buffer, p, B_CONTENT)
-      if (~p) return bipf.seekKey(buffer, p, B_CHANNEL)
-    }
+  seekChannel(buffer) {
+    const pValue = bipf.seekKeyCached(buffer, 0, B_VALUE)
+    if (pValue < 0) return
+    const pValueContent = bipf.seekKeyCached(buffer, pValue, B_CONTENT)
+    if (pValueContent < 0) return
+    return bipf.seekKey(buffer, pValueContent, B_CHANNEL)
   },
 }

--- a/test/prefix.js
+++ b/test/prefix.js
@@ -277,9 +277,8 @@ prepareAndRunTest('Prefix equal', dir, (t, db, raf) => {
       value: helpers.toBipf(
         '%wOtfXXopI3mTHL6F7Y3XXNtpxws9mQdaEocNJuKtAZo=.sha256'
       ),
-      indexType: 'vote',
-      indexName:
-        'value_content_vote_link_%wOtfXXopI3mTHL6F7Y3XXNtpxws9mQdaEocNJuKtAZo=.sha256',
+      indexType: 'value_content_vote_link',
+      indexName: 'value_content_vote_link',
       prefix: 32,
     },
   }


### PR DESCRIPTION
Context: https://github.com/ssb-ngi-pointer/jitdb/pull/208

Uses BIPF 1.6.0's `seekKeyCached` API instead of passing pValue around.

@arj03 How did you run those benchmarks in your PR? Could you try running them with this code? I know you did a good job in #208, but I think `seekKeyCached` is going to help us with `pValueContent` and potentially others.