### PR TITLE
fix seekers in test/helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "atomic-file-rw": "^0.2.1",
     "binary-search-bounds": "^2.0.4",
-    "bipf": "^1.5.4",
+    "bipf": "^1.6.2",
     "crc": "3.6.0",
     "debug": "^4.2.0",
     "fastpriorityqueue": "^0.7.1",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -5,7 +5,6 @@
 const bipf = require('bipf')
 
 const B_KEY = Buffer.from('key')
-const B_VALUE = Buffer.from('value')
 const B_VOTE = Buffer.from('vote')
 const B_LINK = Buffer.from('link')
 const B_AUTHOR = Buffer.from('author')
@@ -19,84 +18,64 @@ const B_PRIVATE = Buffer.from('private')
 const B_CHANNEL = Buffer.from('channel')
 
 module.exports = {
-  toBipf: function (value) {
+  toBipf(value) {
     return bipf.allocAndEncode(value)
   },
 
-  seekKey: function (buffer) {
-    var p = 0 // note you pass in p!
-    return bipf.seekKey(buffer, p, B_KEY)
+  seekKey(buffer) {
+    return bipf.seekKey(buffer, 0, B_KEY)
   },
 
-  seekAuthor: function (buffer) {
-    var p = 0 // note you pass in p!
-    p = bipf.seekKey(buffer, p, B_VALUE)
-
-    if (~p) return bipf.seekKey(buffer, p, B_AUTHOR)
+  seekAuthor(buffer, start, pValue) {
+    if (pValue < 0) return -1
+    return bipf.seekKey(buffer, pValue, B_AUTHOR)
   },
 
-  seekVoteLink: function (buffer) {
-    var p = 0 // note you pass in p!
-    p = bipf.seekKey(buffer, p, B_VALUE)
-    if (!~p) return
-    p = bipf.seekKey(buffer, p, B_CONTENT)
-    if (!~p) return
-    p = bipf.seekKey(buffer, p, B_VOTE)
-    if (!~p) return
-    return bipf.seekKey(buffer, p, B_LINK)
+  seekVoteLink(buffer, start, pValue) {
+    if (pValue < 0) return -1
+    const pValueContent = bipf.seekKey(buffer, pValue, B_CONTENT)
+    if (pValueContent < 0) return -1
+    const pValueContentVote = bipf.seekKey(buffer, pValueContent, B_VOTE)
+    if (pValueContentVote < 0) return -1
+    return bipf.seekKey(buffer, pValueContentVote, B_LINK)
   },
 
-  seekType: function (buffer) {
-    var p = 0 // note you pass in p!
-    p = bipf.seekKey(buffer, p, B_VALUE)
-
-    if (~p) {
-      p = bipf.seekKey(buffer, p, B_CONTENT)
-      if (~p) return bipf.seekKey(buffer, p, B_TYPE)
-    }
+  seekType(buffer, start, pValue) {
+    if (pValue < 0) return -1
+    const pValueContent = bipf.seekKey(buffer, pValue, B_CONTENT)
+    if (pValueContent < 0) return -1
+    return bipf.seekKey(buffer, pValueContent, B_TYPE)
   },
 
-  seekAnimals: function (buffer) {
-    var p = 0 // note you pass in p!
-    p = bipf.seekKey(buffer, p, B_VALUE)
-    if (!~p) return
-    p = bipf.seekKey(buffer, p, B_CONTENT)
-    if (!~p) return
-    return bipf.seekKey(buffer, p, B_ANIMALS)
+  seekAnimals(buffer, start, pValue) {
+    if (pValue < 0) return -1
+    const pValueContent = bipf.seekKey(buffer, pValue, B_CONTENT)
+    if (pValueContent < 0) return -1
+    return bipf.seekKey(buffer, pValueContent, B_ANIMALS)
   },
 
-  pluckWord: function (buffer, start) {
-    var p = start
-    return bipf.seekKey(buffer, p, B_WORD)
+  pluckWord(buffer, start) {
+    return bipf.seekKey(buffer, start, B_WORD)
   },
 
-  seekRoot: function (buffer) {
-    var p = 0 // note you pass in p!
-    p = bipf.seekKey(buffer, p, B_VALUE)
-
-    if (~p) {
-      p = bipf.seekKey(buffer, p, B_CONTENT)
-      if (~p) return bipf.seekKey(buffer, p, B_ROOT)
-    }
+  seekRoot(buffer, start, pValue) {
+    if (pValue < 0) return -1
+    const pValueContent = bipf.seekKey(buffer, pValue, B_CONTENT)
+    if (pValueContent < 0) return -1
+    return bipf.seekKey(buffer, pValueContent, B_ROOT)
   },
 
-  seekPrivate: function (buffer) {
-    var p = 0 // note you pass in p!
-    p = bipf.seekKey(buffer, p, B_VALUE)
-
-    if (~p) {
-      p = bipf.seekKey(buffer, p, B_META)
-      if (~p) return bipf.seekKey(buffer, p, B_PRIVATE)
-    }
+  seekPrivate(buffer, start, pValue) {
+    if (pValue < 0) return -1
+    const pValueMeta = bipf.seekKey(buffer, pValue, B_META)
+    if (pValueMeta < 0) return -1
+    return bipf.seekKey(buffer, pValueMeta, B_PRIVATE)
   },
 
-  seekChannel: function (buffer) {
-    var p = 0 // note you pass in p!
-    p = bipf.seekKey(buffer, p, B_VALUE)
-
-    if (~p) {
-      p = bipf.seekKey(buffer, p, B_CONTENT)
-      if (~p) return bipf.seekKey(buffer, p, B_CHANNEL)
-    }
+  seekChannel(buffer, start, pValue) {
+    if (pValue < 0) return -1
+    const pValueContent = bipf.seekKey(buffer, pValue, B_CONTENT)
+    if (pValueContent < 0) return -1
+    return bipf.seekKey(buffer, pValueContent, B_CHANNEL)
   },
 }

--- a/test/prefix.js
+++ b/test/prefix.js
@@ -277,9 +277,8 @@ prepareAndRunTest('Prefix equal', dir, (t, db, raf) => {
       value: helpers.toBipf(
         '%wOtfXXopI3mTHL6F7Y3XXNtpxws9mQdaEocNJuKtAZo=.sha256'
       ),
-      indexType: 'vote',
-      indexName:
-        'value_content_vote_link_%wOtfXXopI3mTHL6F7Y3XXNtpxws9mQdaEocNJuKtAZo=.sha256',
+      indexType: 'value_content_vote_link',
+      indexName: 'value_content_vote_link',
       prefix: 32,
     },
   }


### PR DESCRIPTION
For issue #210. Doesn't affect code in production because it's just `test/helpers.js` but in ssb-db2 we have real seekers used in production. PR for that coming later.