### PR TITLE
fix crash in getSeqFromOffset

### DIFF
--- a/index.js
+++ b/index.js
@@ -305,7 +305,7 @@ module.exports = function (log, indexesPath) {
     if (offset === -1) return 0
     const { tarr, count } = indexes['seq']
     const seq = bsb.eq(tarr, offset, 0, count - 1)
-    if (seq < 0) throw new Error(`getSeqFromOffset(${offset}) not found`)
+    if (seq < 0) return 0
     return seq
   }
 


### PR DESCRIPTION
Fixes #212 

I am not sure what triggered the `throw` (in a way it would be good to preserve the `throw` so that we can detect and study these cases!), but I'm reverting to returning 0 instead, that's because the [previously implementation was choosing 0 as the seq in case the offset wasnt found](https://github.com/ssb-ngi-pointer/jitdb/commit/540d008dc41b2a4fcc103cb07fbe709548d7f835), and we should probably have preserved that behavior.

