### PR TITLE
add lookup() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,13 @@ updating them, if necessary. This is not a query, as it won't return any
 results. When done, the callback `cb` is just called with the "duration" of
 index preparation as the second argument.
 
+### lookup(operation, seq, cb)
+
+Given one `seq`, lookup its corresponding value on the index specified by
+`operation`, which is either an operation object or a string for the name of a
+core index, such as `'seq'` and `'timestamp'`. The callback `cb` is called with
+the index's value (at that `seq` position) in the 2nd arg.
+
 ### live(operation, cb)
 
 Will setup a pull stream and this in `cb`. The pull stream will emit

--- a/index.js
+++ b/index.js
@@ -1475,7 +1475,7 @@ module.exports = function (log, indexesPath) {
   function lookup(opOrIndexName, seq, cb) {
     const op =
       typeof opOrIndexName === 'string'
-        ? { data: { indexName: 'seq' } }
+        ? { data: { indexName: opOrIndexName } }
         : opOrIndexName
     onReady(() => {
       ensureIndexSync(op, () => {

--- a/index.js
+++ b/index.js
@@ -1472,6 +1472,19 @@ module.exports = function (log, indexesPath) {
     })
   }
 
+  function lookup(opOrIndexName, seq, cb) {
+    const op =
+      typeof opOrIndexName === 'string'
+        ? { data: { indexName: 'seq' } }
+        : opOrIndexName
+    onReady(() => {
+      ensureIndexSync(op, () => {
+        const result = indexes[op.data.indexName].tarr[seq]
+        cb(null, result)
+      })
+    })
+  }
+
   // live will return new messages as they enter the log
   // can be combined with a normal all or paginate first
   function live(op) {
@@ -1616,6 +1629,7 @@ module.exports = function (log, indexesPath) {
     all,
     count,
     prepare,
+    lookup,
     live,
     status: status.obv,
     reindex,

--- a/index.js
+++ b/index.js
@@ -1478,8 +1478,15 @@ module.exports = function (log, indexesPath) {
         ? { data: { indexName: opOrIndexName } }
         : opOrIndexName
     onReady(() => {
+      const indexName = op.data.indexName
+      if (!indexes[indexName]) {
+        return cb(new Error(`Cannot lookup, index ${indexName} not found`))
+      }
+      if (indexes[indexName].lazy) {
+        return cb(new Error(`Cannot lookup, index ${indexName} not loaded`))
+      }
       ensureIndexSync(op, () => {
-        const result = indexes[op.data.indexName].tarr[seq]
+        const result = indexes[indexName].tarr[seq]
         cb(null, result)
       })
     })

--- a/test/lookup.js
+++ b/test/lookup.js
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2021 Anders Rune Jensen
+//
+// SPDX-License-Identifier: Unlicense
+
+const test = require('tape')
+const pull = require('pull-stream')
+const Pushable = require('pull-pushable')
+const validate = require('ssb-validate')
+const ssbKeys = require('ssb-keys')
+const { prepareAndRunTest, addMsg, helpers } = require('./common')()
+const rimraf = require('rimraf')
+const mkdirp = require('mkdirp')
+const {
+  query,
+  and,
+  or,
+  not,
+  equal,
+  where,
+  slowEqual,
+  includes,
+  slowIncludes,
+  gt,
+  gte,
+  lt,
+  lte,
+  deferred,
+  liveSeqs,
+  seqs,
+  offsets,
+  fromDB,
+  paginate,
+  batch,
+  startFrom,
+  live,
+  count,
+  descending,
+  sortByArrival,
+  asOffsets,
+  toCallback,
+  toPromise,
+  toPullStream,
+  toAsyncIter,
+  slowPredicate,
+  slowAbsent,
+  absent,
+} = require('../operators')
+
+const dir = '/tmp/jitdb-lookup-api'
+rimraf.sync(dir)
+mkdirp.sync(dir)
+
+const alice = ssbKeys.generate('ed25519', Buffer.alloc(32, 'a'))
+const bob = ssbKeys.generate('ed25519', Buffer.alloc(32, 'b'))
+
+prepareAndRunTest('lookup "seq"', dir, (t, jitdb, log) => {
+  log.append(Buffer.from('hello'), (e1, offset0) => {
+    log.append(Buffer.from('world'), (e2, offset1) => {
+      log.append(Buffer.from('foobar'), (e3, offset2) => {
+        log.onDrain(() => {
+          jitdb.lookup('seq', 0, (err, offset) => {
+            t.error(err, 'no error')
+            t.equals(offset, offset0)
+            jitdb.lookup('seq', 1, (err, offset) => {
+              t.error(err, 'no error')
+              t.equals(offset, offset1)
+              jitdb.lookup('seq', 2, (err, offset) => {
+                t.error(err, 'no error')
+                t.equals(offset, offset2)
+                t.end()
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+})
+
+prepareAndRunTest('lookup operation', dir, (t, jitdb, log) => {
+  const msg1 = { type: 'post', text: '1st', animals: ['cat', 'dog', 'bird'] }
+  const msg2 = { type: 'contact', text: '2nd', animals: ['bird'] }
+  const msg3 = { type: 'post', text: '3rd', animals: ['cat'] }
+
+  let state = validate.initial()
+  state = validate.appendNew(state, null, alice, msg1, Date.now())
+  state = validate.appendNew(state, null, alice, msg2, Date.now() + 1)
+  state = validate.appendNew(state, null, alice, msg3, Date.now() + 2)
+
+  addMsg(state.queue[0].value, log, (e1, m1) => {
+    addMsg(state.queue[1].value, log, (e2, m2) => {
+      addMsg(state.queue[2].value, log, (e3, m3) => {
+        const op = slowEqual('value.author', 'whatever', {
+          prefix: 32,
+          indexType: 'value_author',
+        })
+        jitdb.prepare(op, (err) => {
+          t.error(err, 'no error')
+          jitdb.lookup(op, 0, (err, authorAsUint32LE) => {
+            t.error(err, 'no error')
+            const buf = Buffer.alloc(4)
+            buf.writeUInt32LE(authorAsUint32LE)
+            const prefix = buf.toString('ascii')
+            t.equals(prefix, alice.id.slice(0, 4))
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})

--- a/test/lookup.js
+++ b/test/lookup.js
@@ -1,57 +1,19 @@
-// SPDX-FileCopyrightText: 2021 Anders Rune Jensen
+// SPDX-FileCopyrightText: 2022 Anders Rune Jensen
 //
 // SPDX-License-Identifier: Unlicense
 
-const test = require('tape')
-const pull = require('pull-stream')
-const Pushable = require('pull-pushable')
 const validate = require('ssb-validate')
 const ssbKeys = require('ssb-keys')
-const { prepareAndRunTest, addMsg, helpers } = require('./common')()
+const { prepareAndRunTest, addMsg } = require('./common')()
 const rimraf = require('rimraf')
 const mkdirp = require('mkdirp')
-const {
-  query,
-  and,
-  or,
-  not,
-  equal,
-  where,
-  slowEqual,
-  includes,
-  slowIncludes,
-  gt,
-  gte,
-  lt,
-  lte,
-  deferred,
-  liveSeqs,
-  seqs,
-  offsets,
-  fromDB,
-  paginate,
-  batch,
-  startFrom,
-  live,
-  count,
-  descending,
-  sortByArrival,
-  asOffsets,
-  toCallback,
-  toPromise,
-  toPullStream,
-  toAsyncIter,
-  slowPredicate,
-  slowAbsent,
-  absent,
-} = require('../operators')
+const { slowEqual } = require('../operators')
 
 const dir = '/tmp/jitdb-lookup-api'
 rimraf.sync(dir)
 mkdirp.sync(dir)
 
 const alice = ssbKeys.generate('ed25519', Buffer.alloc(32, 'a'))
-const bob = ssbKeys.generate('ed25519', Buffer.alloc(32, 'b'))
 
 prepareAndRunTest('lookup "seq"', dir, (t, jitdb, log) => {
   log.append(Buffer.from('hello'), (e1, offset0) => {


### PR DESCRIPTION
Context: issue https://github.com/ssb-ngi-pointer/jitdb/issues/215 and improving the performance of deletes in ssb-db2.

I already confirmed that using this API and changing the implementation of `ssb-db2`'s `del()` made deletes become more than 10x faster, so this API should be worth adding.

It basically gives you raw access to index entries.