### PR TITLE
add APIs necessary for log compaction algorithms

### DIFF
--- a/index.js
+++ b/index.js
@@ -1639,9 +1639,11 @@ module.exports = function (log, indexesPath) {
     push(
       push.values(Object.entries(indexes)),
       push.asyncMap(([indexName, index], cb) => {
-        if (coreIndexNames.includes(indexName)) return cb()
-
-        if (index.lazy) {
+        if (coreIndexNames.includes(indexName)) {
+          resetIndex(index)
+          saveCoreIndex(indexName, index, seq)
+          cb()
+        } else if (index.lazy) {
           loadLazyIndex(indexName, (err) => {
             if (err) return cb(err)
 

--- a/index.js
+++ b/index.js
@@ -43,10 +43,8 @@ module.exports = function (log, indexesPath) {
   let waiting = []
   const waitingCompaction = []
   const coreIndexNames = ['seq', 'timestamp', 'sequence']
-  const indexingActive = Obv()
-  const queriesActive = Obv()
-  indexingActive.set(0)
-  queriesActive.set(0)
+  const indexingActive = Obv().set(0)
+  const queriesActive = Obv().set(0)
 
   loadIndexes(() => {
     debug('loaded indexes', Object.keys(indexes))

--- a/index.js
+++ b/index.js
@@ -88,9 +88,7 @@ module.exports = function (log, indexesPath) {
 
   log.compactionProgress((stats) => {
     if (stats.done && waitingCompaction.length > 0) {
-      for (let i = 0, n = waitingCompaction.length; i < n; ++i) {
-        waitingCompaction[i]()
-      }
+      for (const cb of waitingCompaction) cb()
       waitingCompaction.length = 0
     }
   })

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "typedfastbitset": "~0.2.1"
   },
   "peerDependencies": {
-    "async-append-only-log": "^4.0.0"
+    "async-append-only-log": "ssb-ngi-pointer/async-append-only-log#compact-reindex"
   },
   "devDependencies": {
-    "async-append-only-log": "^4.0.0",
+    "async-append-only-log": "ssb-ngi-pointer/async-append-only-log#compact-reindex",
     "expose-gc": "^1.0.0",
     "flumecodec": "0.0.1",
     "flumelog-offset": "3.4.4",

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "typedfastbitset": "~0.2.1"
   },
   "peerDependencies": {
-    "async-append-only-log": "ssb-ngi-pointer/async-append-only-log#compact-reindex"
+    "async-append-only-log": "^4.2.1"
   },
   "devDependencies": {
-    "async-append-only-log": "ssb-ngi-pointer/async-append-only-log#compact-reindex",
+    "async-append-only-log": "^4.2.1",
     "expose-gc": "^1.0.0",
     "flumecodec": "0.0.1",
     "flumelog-offset": "3.4.4",

--- a/test/add.js
+++ b/test/add.js
@@ -165,7 +165,7 @@ prepareAndRunTest('Base', dir, (t, db, raf) => {
 })
 
 prepareAndRunTest('Update index', dir, (t, db, raf) => {
-  t.plan(9)
+  t.plan(7)
   t.timeoutAfter(5000)
   const msg = { type: 'post', text: 'Testing!' }
   let state = validate.initial()
@@ -183,11 +183,6 @@ prepareAndRunTest('Update index', dir, (t, db, raf) => {
   }
 
   const expectedIndexingActive = [0, 1 /* seq */, 0, 1 /* type_post */, 0]
-  const expectedStatus = [{ seq: -1, timestamp: -1, sequence: -1 }, {}]
-  db.status((stats) => {
-    t.deepEqual(stats, expectedStatus.shift(), 'status matches')
-    if (!expectedStatus.length && !expectedIndexingActive.length) t.end()
-  })
 
   addMsg(state.queue[0].value, raf, (err, msg1) => {
     db.all(typeQuery, 0, false, false, 'declared', (err, results) => {
@@ -195,7 +190,6 @@ prepareAndRunTest('Update index', dir, (t, db, raf) => {
 
       db.indexingActive((x) => {
         t.equals(x, expectedIndexingActive.shift(), 'indexingActive matches')
-        if (!expectedStatus.length && !expectedIndexingActive.length) t.end()
       })
 
       addMsg(state.queue[1].value, raf, (err, msg1) => {

--- a/test/operators.js
+++ b/test/operators.js
@@ -625,6 +625,11 @@ prepareAndRunTest('not operator', dir, (t, db, raf) => {
 
   addMsg(state.queue[0].value, raf, (e1, msg1) => {
     addMsg(state.queue[1].value, raf, (e2, msg2) => {
+      const expectedQueriesActive = [0, 1, 0]
+      db.queriesActive((x) => {
+        t.equals(x, expectedQueriesActive.shift(), 'queriesActive matches')
+      })
+
       pull(
         query(
           fromDB(db),
@@ -639,6 +644,7 @@ prepareAndRunTest('not operator', dir, (t, db, raf) => {
           t.equal(msgs.length, 1, 'page has one messages')
           t.equal(msgs[0].value.author, bob.id)
           t.equal(msgs[0].value.content.type, 'post')
+          t.equal(expectedQueriesActive.length, 0)
           t.end()
         })
       )


### PR DESCRIPTION
Context: https://github.com/ssb-ngi-pointer/jitdb/issues/199

**Problem 1:** we need to know when is indexing ongoing and/or when is querying ongoing, because we don't want compact to happen in parallel with those.

**Problem 2:** if compaction is ongoing, we can't allow JITDB queries to start.

**Problem 3:** `reindex` has to rebuild also the core indexes.

**Solution:**

- Introduces the public APIs `indexingActive` and `queriesActive` which are Obz's that emit numbers of how many are active at the moment. 
- Monitor the status of compaction and guard the queries to wait for compaction to end first
- `reindex` rebuilds also the core indexes

These changes are already used and tested in https://github.com/ssb-ngi-pointer/ssb-db2/pull/339